### PR TITLE
#54 - Repetitive parsing results should be cached

### DIFF
--- a/src/main/java/com/jcabi/xml/XMLDocument.java
+++ b/src/main/java/com/jcabi/xml/XMLDocument.java
@@ -112,6 +112,12 @@ public final class XMLDocument implements XML {
      */
     private final transient boolean leaf;
 
+    /**
+     * Actual XML document node. Needs to be an Object so the class is still
+     * recognized as @Immutable.
+     */
+    private final transient Object node;
+
     static {
         if (XMLDocument.DFACTORY.getClass().getName().contains("xerces")) {
             try {
@@ -164,12 +170,12 @@ public final class XMLDocument implements XML {
      * {@link NamespaceContext}, which already defines a
      * number of namespaces, see {@link XMLDocument#XMLDocument(String)}.
      *
-     * @param node DOM source
+     * @param nde DOM source
      * @since 0.2
      */
     public XMLDocument(@NotNull(message = "node can't be NULL")
-        final Node node) {
-        this(node, new XPathContext(), !(node instanceof Document));
+        final Node nde) {
+        this(nde, new XPathContext(), !(nde instanceof Document));
     }
 
     /**
@@ -267,15 +273,16 @@ public final class XMLDocument implements XML {
 
     /**
      * Private ctor.
-     * @param node The source
+     * @param nde The source
      * @param ctx Namespace context
      * @param lfe Is it a leaf node?
      */
-    private XMLDocument(final Node node, final XPathContext ctx,
+    private XMLDocument(final Node nde, final XPathContext ctx,
         final boolean lfe) {
-        this.xml = XMLDocument.asString(node);
+        this.xml = XMLDocument.asString(nde);
         this.context = ctx;
         this.leaf = lfe;
+        this.node = nde;
     }
 
     @Override
@@ -286,16 +293,7 @@ public final class XMLDocument implements XML {
     @Override
     @NotNull(message = "node is never NULL")
     public Node node() {
-        final Document doc = new DomParser(
-            XMLDocument.DFACTORY, this.xml
-        ).document();
-        final Node node;
-        if (this.leaf) {
-            node = doc.getDocumentElement();
-        } else {
-            node = doc;
-        }
-        return node;
+        return (Node) this.node;
     }
 
     @Override

--- a/src/main/java/com/jcabi/xml/XMLDocument.java
+++ b/src/main/java/com/jcabi/xml/XMLDocument.java
@@ -116,7 +116,7 @@ public final class XMLDocument implements XML {
      * Actual XML document node. Needs to be an Object so the class is still
      * recognized as @Immutable.
      */
-    private final transient Object node;
+    private final transient Object cache;
 
     static {
         if (XMLDocument.DFACTORY.getClass().getName().contains("xerces")) {
@@ -170,12 +170,12 @@ public final class XMLDocument implements XML {
      * {@link NamespaceContext}, which already defines a
      * number of namespaces, see {@link XMLDocument#XMLDocument(String)}.
      *
-     * @param nde DOM source
+     * @param node DOM source
      * @since 0.2
      */
     public XMLDocument(@NotNull(message = "node can't be NULL")
-        final Node nde) {
-        this(nde, new XPathContext(), !(nde instanceof Document));
+        final Node node) {
+        this(node, new XPathContext(), !(node instanceof Document));
     }
 
     /**
@@ -273,16 +273,16 @@ public final class XMLDocument implements XML {
 
     /**
      * Private ctor.
-     * @param nde The source
+     * @param node The source
      * @param ctx Namespace context
      * @param lfe Is it a leaf node?
      */
-    private XMLDocument(final Node nde, final XPathContext ctx,
+    private XMLDocument(final Node node, final XPathContext ctx,
         final boolean lfe) {
-        this.xml = XMLDocument.asString(nde);
+        this.xml = XMLDocument.asString(node);
         this.context = ctx;
         this.leaf = lfe;
-        this.node = nde;
+        this.cache = node;
     }
 
     @Override
@@ -293,7 +293,7 @@ public final class XMLDocument implements XML {
     @Override
     @NotNull(message = "node is never NULL")
     public Node node() {
-        return (Node) this.node;
+        return (Node) this.cache;
     }
 
     @Override

--- a/src/test/java/com/jcabi/xml/XMLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XMLDocumentTest.java
@@ -344,6 +344,19 @@ public final class XMLDocumentTest {
     }
 
     /**
+     * XMLDocument parse result is cached.
+     * @throws Exception If something goes wrong inside
+     */
+    @Test
+    public void cachesParseResult() throws Exception {
+        final XML doc = new XMLDocument("<?xml version='1.1'?><f/>");
+        MatcherAssert.assertThat(
+            doc.node(),
+            Matchers.sameInstance(doc.node())
+        );
+    }
+
+    /**
      * XMLDocument can compare to itself.
      * @throws Exception If something goes wrong inside
      */


### PR DESCRIPTION
Cached the parse result. Had to use a field of `Object` type to maintain immutability. 
Introduced a test to check that the result is indeed cached.