### PR TITLE
#94 fixed NPE when schema location missed

### DIFF
--- a/src/main/java/com/jcabi/xml/ClasspathResolver.java
+++ b/src/main/java/com/jcabi/xml/ClasspathResolver.java
@@ -46,10 +46,12 @@ class ClasspathResolver implements LSResourceResolver {
     // @checkstyle ParameterNumber (1 line)
     public LSInput resolveResource(final String type, final String namespaceuri,
         final String publicid, final String systemid, final String baseuri) {
-        final InputStream stream = getClass().getResourceAsStream(systemid);
         LSInput input = null;
-        if (stream != null) {
-            input = new ClasspathInput(publicid, systemid, stream);
+        if (systemid != null) {
+            final InputStream stream = getClass().getResourceAsStream(systemid);
+            if (stream != null) {
+                input = new ClasspathInput(publicid, systemid, stream);
+            }
         }
         return input;
     }

--- a/src/test/java/com/jcabi/xml/StrictXMLTest.java
+++ b/src/test/java/com/jcabi/xml/StrictXMLTest.java
@@ -275,4 +275,15 @@ public final class StrictXMLTest {
             )
         );
     }
+
+    /**
+     * StrictXML can handle XML without schemaLocation.
+     * @throws Exception If something goes wrong inside
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void handlesXmlWithoutSchemaLocation() throws Exception {
+        new StrictXML(
+            new XMLDocument("<a></a>")
+        );
+    }
 }


### PR DESCRIPTION
For #94

* added a new unit test
* fixed NPE when the schemaLocation element missed in the input XML
