### PR TITLE
Up version for some dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-all</artifactId>
-                        <version>2.4.5</version>
+                        <version>2.4.7</version>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.reb4j</groupId>
@@ -187,7 +187,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.10</version>
+                <version>1.12</version>
                 <executions>
                     <execution>
                         <id>add-source</id>
@@ -258,7 +258,7 @@
                     <plugin>
                         <groupId>org.eluder.coveralls</groupId>
                         <artifactId>coveralls-maven-plugin</artifactId>
-                        <version>4.1.0</version>
+                        <version>4.2.0</version>
                         <executions>
                             <execution>
                                 <phase>site</phase>


### PR DESCRIPTION
PR for #74 
As pointed out, there are some outdated dependencies and 1 security issue with ``xercesImpl : 2.11``
There are 4 outdated dependencies, one of them being ``xml-apis``

I updated 3 of them, leaving ``xml-apis`` as it is, since there is a comment from the architect about it, in ``pom.xml``
![image](https://cloud.githubusercontent.com/assets/6305156/17853434/12a153a6-6875-11e6-8ab6-ce0ec6226e94.png)

The issue with ``xercesImpl`` cannot be solved at the moment, since it covers all the versions ``<=2.11``. and there is no version higher than ``2.11`` right now. However, the lib is ``test-scoped``, so maybe this issue can be ignored.

![image](https://cloud.githubusercontent.com/assets/6305156/17853478/57c4d034-6875-11e6-939c-700e4ba38912.png)
