### PR TITLE
#72 Ignore generated Patterns class for coveralls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,23 +225,21 @@
         </profile>
         <profile>
             <id>coveralls</id>
-            <!--
-            @todo #70:30m/DEV This reporting doesn't work, becuase of
-             a conflict with Patterns.java file, which is generated on
-             fly and doesn't really have a source. See the log here,
-             for example: http://www.rultor.com/t/5393-146659058
-             Let's fix it somehow and enable this profile again.
-            -->
-            <!--
             <activation>
                 <file><exists>pom.xml</exists></file>
             </activation>
-            -->
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>cobertura-maven-plugin</artifactId>
+                        <configuration>
+                            <instrumentation>
+                                <excludes>
+                                    <exclude>com/jcabi/xml/Patterns.class</exclude>
+                                </excludes>
+                            </instrumentation>
+                        </configuration>
                         <executions>
                             <execution>
                                 <phase>site</phase>


### PR DESCRIPTION
For issue #72 

Ignoring generated file to omit coveralls error.

Issue and solution found in coveralls maven plugin: https://github.com/trautonen/coveralls-maven-plugin/issues/57