### PR TITLE
Preserve DOM structure of XML document when navigating by xpath.

### DIFF
--- a/src/main/java/com/jcabi/xml/XMLDocument.java
+++ b/src/main/java/com/jcabi/xml/XMLDocument.java
@@ -103,11 +103,6 @@ public final class XMLDocument implements XML {
      * Encapsulated String representation of this XML document.
      */
     private final transient String xml;
-    
-    /**
-     * DOM representation of this document
-     */
-    private final transient Node node;
 
     /**
      * Is it a leaf node (Element, not a Document)?
@@ -274,7 +269,6 @@ public final class XMLDocument implements XML {
      */
     private XMLDocument(final Node node, final XPathContext ctx,
         final boolean lfe) {
-        this.node = node;
         this.xml = XMLDocument.asString(node);
         this.context = ctx;
         this.leaf = lfe;
@@ -288,7 +282,7 @@ public final class XMLDocument implements XML {
 
     @Override
     public Node node() {
-        return this.node;
+        return Node.class.cast(this.cache);
     }
 
     @Override
@@ -373,7 +367,7 @@ public final class XMLDocument implements XML {
     public XML merge(final NamespaceContext ctx) {
         return new XMLDocument(this.node(), this.context.merge(ctx), this.leaf);
     }
-    
+
     /**
      * Retrieve XPath query result. Supports returning {@link NodeList} and
      * {@link String} types.

--- a/src/main/java/com/jcabi/xml/XMLDocument.java
+++ b/src/main/java/com/jcabi/xml/XMLDocument.java
@@ -103,6 +103,11 @@ public final class XMLDocument implements XML {
      * Encapsulated String representation of this XML document.
      */
     private final transient String xml;
+    
+    /**
+     * DOM representation of this document
+     */
+    private final transient Node node;
 
     /**
      * Is it a leaf node (Element, not a Document)?
@@ -269,6 +274,7 @@ public final class XMLDocument implements XML {
      */
     private XMLDocument(final Node node, final XPathContext ctx,
         final boolean lfe) {
+        this.node = node;
         this.xml = XMLDocument.asString(node);
         this.context = ctx;
         this.leaf = lfe;
@@ -282,14 +288,7 @@ public final class XMLDocument implements XML {
 
     @Override
     public Node node() {
-        final Node castCache = Node.class.cast(this.cache);
-        final Node answer;
-        if (castCache instanceof Document) {
-            answer = castCache.cloneNode(true);
-        } else {
-            answer = this.createImportedNode(castCache);
-        }
-        return answer;
+        return this.node;
     }
 
     @Override
@@ -374,24 +373,7 @@ public final class XMLDocument implements XML {
     public XML merge(final NamespaceContext ctx) {
         return new XMLDocument(this.node(), this.context.merge(ctx), this.leaf);
     }
-
-    /**
-     * Clones a node and imports it in a new document.
-     * @param node A node to clone.
-     * @return A cloned node imported in a dedicated document.
-     */
-    private Node createImportedNode(final Node node) {
-        final Document document;
-        try {
-            document = DFACTORY.newDocumentBuilder().newDocument();
-        } catch (final ParserConfigurationException ex) {
-            throw new IllegalStateException(ex);
-        }
-        final Node imported = document.importNode(node, true);
-        document.appendChild(imported);
-        return imported;
-    }
-
+    
     /**
      * Retrieve XPath query result. Supports returning {@link NodeList} and
      * {@link String} types.
@@ -482,5 +464,4 @@ public final class XMLDocument implements XML {
         }
         return result.getNode();
     }
-
 }

--- a/src/test/java/com/jcabi/xml/XMLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XMLDocumentTest.java
@@ -134,6 +134,22 @@ public final class XMLDocumentTest {
             Matchers.equalTo("1")
         );
     }
+    
+    /**
+     * @throws Exception 
+     */
+    @Test
+    public void findsParentNodeWithXpath() throws Exception {
+        final XML doc = new XMLDocument(
+            IOUtils.toInputStream("<root><item1/><item2/><item3/></root>")
+        );
+        final XML item2Node = doc.nodes("//root/item2").get(0);
+        
+        MatcherAssert.assertThat(
+            item2Node.nodes("..").get(0).xpath("name()").get(0),
+            Matchers.equalTo("root")
+        );
+    }
 
     /**
      * XMLDocument can convert itself back to XML.

--- a/src/test/java/com/jcabi/xml/XMLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XMLDocumentTest.java
@@ -134,17 +134,17 @@ public final class XMLDocumentTest {
             Matchers.equalTo("1")
         );
     }
-    
+
     /**
-     * @throws Exception 
+     * XMLDocument preserves DOM structure when executing XPath queries.
+     * @throws Exception If something goes wrong inside
      */
     @Test
-    public void findsParentNodeWithXpath() throws Exception {
+    public void preservesDomStructureWhenXpath() throws Exception {
         final XML doc = new XMLDocument(
             IOUtils.toInputStream("<root><item1/><item2/><item3/></root>")
         );
         final XML item2Node = doc.nodes("//root/item2").get(0);
-        
         MatcherAssert.assertThat(
             item2Node.nodes("..").get(0).xpath("name()").get(0),
             Matchers.equalTo("root")


### PR DESCRIPTION
Fix for https://github.com/jcabi/jcabi-xml/issues/131.