### PR TITLE
Update URL for Javadoc badge's image

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PDD status](http://www.0pdd.com/svg?name=jcabi/jcabi-xml)](http://www.0pdd.com/p?name=jcabi/jcabi-xml)
 [![Build status](https://ci.appveyor.com/api/projects/status/323ak1323abk3x30/branch/master?svg=true)](https://ci.appveyor.com/project/yegor256/jcabi-xml/branch/master)
 [![Coverage Status](https://coveralls.io/repos/jcabi/jcabi-xml/badge.svg?branch=__rultor&service=github)](https://coveralls.io/github/jcabi/jcabi-xml?branch=__rultor)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.jcabi/jcabi-xml/badge.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-xml)
+[![Javadoc](https://javadoc.io/badge/com.jcabi/jcabi-xml.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-xml)
 
 [![jpeek report](http://i.jpeek.org/com.jcabi/jcabi-xml/badge.svg)](http://i.jpeek.org/com.jcabi/jcabi-xml/)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-xml/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-xml)


### PR DESCRIPTION
OpenShit Online V2 is closed and this domain is not accessible anymore.
And javadoc.io introduce badges hosted directly on javadoc.io