### PR TITLE
(#149) xpath result List<String> is not transitive

### DIFF
--- a/src/main/java/com/jcabi/xml/ListWrapper.java
+++ b/src/main/java/com/jcabi/xml/ListWrapper.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
-import lombok.EqualsAndHashCode;
 import org.w3c.dom.Node;
 
 /**
@@ -84,10 +83,8 @@ import org.w3c.dom.Node;
  * @since 0.1
  * @param <T> Time of items
  */
-@EqualsAndHashCode(of = { "original", "dom", "xpath" })
 @SuppressWarnings("PMD.TooManyMethods")
 final class ListWrapper<T> implements List<T> {
-
     /**
      * The original list.
      */
@@ -110,6 +107,7 @@ final class ListWrapper<T> implements List<T> {
      * @param addr Address
      */
     ListWrapper(final List<T> list, final Node node, final String addr) {
+        super();
         this.original = list;
         this.dom = node;
         this.xpath = addr;
@@ -198,6 +196,16 @@ final class ListWrapper<T> implements List<T> {
     @Override
     public ListIterator<T> listIterator(final int index) {
         return this.original.listIterator(index);
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return this.original.equals(other);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.original.hashCode();
     }
 
     @Override

--- a/src/test/java/com/jcabi/xml/XMLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XMLDocumentTest.java
@@ -33,6 +33,8 @@ import com.google.common.io.Files;
 import com.jcabi.matchers.XhtmlMatchers;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -41,6 +43,7 @@ import org.cactoos.io.LengthOf;
 import org.cactoos.io.TeeInput;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -72,6 +75,38 @@ public final class XMLDocumentTest {
         MatcherAssert.assertThat(
             doc.xpath("/r/a/text()"),
             Matchers.hasItem("\u0443\u0440\u0430!")
+        );
+    }
+
+    /**
+     * The list returned by xpath
+     * is equal to java.util.List.
+     */
+    @Test
+    public void findWithXpathListEqualsToJavaUtilList() {
+        MatcherAssert.assertThat(
+            new XMLDocument(
+                "<does><not><matter/></not></does>"
+            ).xpath("//missing/text()"),
+            new IsEqual<>(
+                Collections.<String>emptyList()
+            )
+        );
+        MatcherAssert.assertThat(
+            new XMLDocument(
+                "<root><item>first</item><item>second</item></root>"
+            ).xpath("//root/item[1]/text()"),
+            new IsEqual<>(
+                Collections.singletonList("first")
+            )
+        );
+        MatcherAssert.assertThat(
+            new XMLDocument(
+                "<root><item>abc</item><item>def</item></root>"
+            ).xpath("/root/item/text()"),
+            new IsEqual<>(
+                Arrays.asList("abc", "def")
+            )
         );
     }
 


### PR DESCRIPTION
#149 

xpath() returns List<String>
however this List<String> is not equal to java.util.List<String>

this PR:
- turns off the lombok automatic equals & hashcode codegen
- delegates equals and hashcode to java.util.List
