### PR TITLE
feat(#213): Add SaxonDocument to enable XPath 2.0 features

### DIFF
--- a/src/main/java/com/jcabi/xml/SaxonDocument.java
+++ b/src/main/java/com/jcabi/xml/SaxonDocument.java
@@ -43,7 +43,14 @@ import net.sf.saxon.s9api.XdmItem;
 import net.sf.saxon.s9api.XdmNode;
 import org.w3c.dom.Node;
 
-public class SaxonDocument implements XML {
+/**
+ * Saxon XML document.
+ *
+ * <p>Objects of this class are immutable, but NOT thread-safe.
+ *
+ * @since 0.28
+ */
+public final class SaxonDocument implements XML {
 
     /**
      * Saxon processor.
@@ -53,7 +60,7 @@ public class SaxonDocument implements XML {
     /**
      * Saxon document builder.
      */
-    private static final DocumentBuilder DOCUMENT_BUILDER = SaxonDocument.SAXON.newDocumentBuilder();
+    private static final DocumentBuilder DOC_BUILDER = SaxonDocument.SAXON.newDocumentBuilder();
 
     /**
      * Saxon XPath compiler.
@@ -69,7 +76,7 @@ public class SaxonDocument implements XML {
     /**
      * Saxon XML document node.
      */
-    private final XdmNode node;
+    private final XdmNode xdm;
 
     /**
      * Public constructor from XML as string text.
@@ -81,17 +88,17 @@ public class SaxonDocument implements XML {
 
     /**
      * Public constructor from Saxon XML document node.
-     * @param node Saxon XML document node.
+     * @param xml Saxon XML document node.
      */
-    public SaxonDocument(final XdmNode node) {
-        this.node = node;
+    public SaxonDocument(final XdmNode xml) {
+        this.xdm = xml;
     }
 
     @Override
     public List<String> xpath(final String query) {
         try {
             final XPathSelector selector = SaxonDocument.XPATH_COMPILER.compile(query).load();
-            selector.setContextItem(this.node);
+            selector.setContextItem(this.xdm);
             return selector.evaluate()
                 .stream()
                 .map(XdmItem::getStringValue)
@@ -139,7 +146,7 @@ public class SaxonDocument implements XML {
      */
     private static XdmNode node(final String text) {
         try {
-            return SaxonDocument.DOCUMENT_BUILDER
+            return SaxonDocument.DOC_BUILDER
                 .build(new StreamSource(new StringReader(text)));
         } catch (final SaxonApiException exception) {
             throw new IllegalArgumentException(

--- a/src/main/java/com/jcabi/xml/SaxonDocument.java
+++ b/src/main/java/com/jcabi/xml/SaxonDocument.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2012-2022, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.xml;
+
+import java.io.StringReader;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.transform.stream.StreamSource;
+import net.sf.saxon.s9api.DocumentBuilder;
+import net.sf.saxon.s9api.Processor;
+import net.sf.saxon.s9api.SaxonApiException;
+import net.sf.saxon.s9api.XPathCompiler;
+import net.sf.saxon.s9api.XPathExecutable;
+import net.sf.saxon.s9api.XPathSelector;
+import net.sf.saxon.s9api.XdmItem;
+import net.sf.saxon.s9api.XdmNode;
+import net.sf.saxon.s9api.XdmValue;
+import org.w3c.dom.Node;
+
+public class SaxonDocument implements XML {
+
+    private final String text;
+
+    /**
+     * Public constructor from XML as string text.
+     *
+     * @param text XML document body.
+     */
+    public SaxonDocument(final String text) {
+        this.text = text;
+    }
+
+    @Override
+    public List<String> xpath(final String query) {
+        Processor processor = new Processor(false);
+        try {
+            DocumentBuilder builder = processor.newDocumentBuilder();
+            XdmNode doc = builder.build(new StreamSource(new StringReader(text)));
+            XPathCompiler xpathCompiler = processor.newXPathCompiler();
+            XPathExecutable xpathExec = xpathCompiler.compile(query);
+            XPathSelector selector = xpathExec.load();
+            selector.setContextItem(doc);
+            XdmValue result = selector.evaluate();
+            return result.stream().map(XdmItem::getStringValue).collect(Collectors.toList());
+        } catch (SaxonApiException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    public List<XML> nodes(final String query) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public XML registerNs(final String prefix, final Object uri) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public XML merge(final NamespaceContext context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node node() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/jcabi/xml/XML.java
+++ b/src/main/java/com/jcabi/xml/XML.java
@@ -51,6 +51,19 @@ import org.w3c.dom.Node;
  *
  * <p>Implementation of this interface must be immutable and thread-safe.
  *
+ * <p> In most cases, you can use the {@link XMLDocument} implementation. It
+ * implements all required features and will be sufficient for most practical tasks.
+ * The only problem with that implementation is that it uses javax.xml classes under
+ * the hood. The issue with the default java implementation is that it only supports
+ * XPath 1.0. If you require XPath 2.0 support and beyond, you can use the Saxon
+ * implementation of {@link XML} - {@link SaxonDocument}. It is based on the Saxon
+ * library and supports XPath 2.0 and higher.
+ * You can read more about Java XPath versioning problems in the following threads:
+ * <ul>
+ *   <li><a href="https://stackoverflow.com/questions/6624149/xpath-2-0-for-java-possible">xpath 2.0 for java possible</a></li>
+ *   <li><a href="https://stackoverflow.com/questions/5802895/does-jdk-6-support-all-features-of-xpath-2-0/5803028#5803028">does JDK 6 support all features of XPath 2.0?</a></li>
+ * </ul>
+ *
  * @see XMLDocument
  * @since 0.1
  * @checkstyle AbbreviationAsWordInNameCheck (5 lines)

--- a/src/test/java/com/jcabi/xml/SaxonDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/SaxonDocumentTest.java
@@ -1,10 +1,43 @@
+/*
+ * Copyright (c) 2012-2022, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.jcabi.xml;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
-class SaxonDocumentTest {
+/**
+ * Test case for {@link SaxonDocument}.
+ * @since 0.28
+ */
+final class SaxonDocumentTest {
 
     @Test
     void findsXpathWithFunctionThatReturnsSeveralItems() {

--- a/src/test/java/com/jcabi/xml/SaxonDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/SaxonDocumentTest.java
@@ -1,0 +1,19 @@
+package com.jcabi.xml;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+class SaxonDocumentTest {
+
+    @Test
+    void findsXpathWithFunctionThatReturnsSeveralItems() {
+        MatcherAssert.assertThat(
+            "XMLDocument can handle XPath 2.0 feature - XPath evaluation of concat method, but it can't",
+            new SaxonDocument(
+                "<o><o base='a' ver='1'/><o base='b' ver='2'/></o>"
+            ).xpath("//o[@base and @ver]/concat(@base,'|',@ver)"),
+            Matchers.hasItems("a|1", "b|2")
+        );
+    }
+}

--- a/src/test/java/com/jcabi/xml/SaxonDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/SaxonDocumentTest.java
@@ -40,13 +40,24 @@ import org.junit.jupiter.api.Test;
 final class SaxonDocumentTest {
 
     @Test
-    void findsXpathWithFunctionThatReturnsSeveralItems() {
+    void findsXpathWithConcatFunctionThatReturnsSeveralItems() {
         MatcherAssert.assertThat(
-            "XMLDocument can handle XPath 2.0 feature - XPath evaluation of concat method, but it can't",
+            "SaxonDocument can handle XPath 2.0 feature - XPath evaluation of concat method, but it can't",
             new SaxonDocument(
                 "<o><o base='a' ver='1'/><o base='b' ver='2'/></o>"
             ).xpath("//o[@base and @ver]/concat(@base,'|',@ver)"),
             Matchers.hasItems("a|1", "b|2")
+        );
+    }
+
+    @Test
+    void findsXpathWithStringJoinFunctionThatReturnsSeveralItems() {
+        MatcherAssert.assertThat(
+            "SaxonDocument can handle XPath 2.0 feature - XPath evaluation of string-join method, but it can't",
+            new SaxonDocument(
+                "<o><o base='a'/><o base='b' ver='2'/><o base='c'/></o>"
+            ).xpath("//o[@base]/string-join((@base,@ver),'|')"),
+            Matchers.hasItems("a", "b|2", "c")
         );
     }
 }

--- a/src/test/java/com/jcabi/xml/XMLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XMLDocumentTest.java
@@ -45,7 +45,6 @@ import org.cactoos.scalar.LengthOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;

--- a/src/test/java/com/jcabi/xml/XMLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XMLDocumentTest.java
@@ -56,12 +56,6 @@ import org.w3c.dom.Node;
  *
  * @since 0.1
  * @checkstyle AbbreviationAsWordInNameCheck (20 lines)
- * @todo #221:30min Implement XPath 2.0 evaluations.
- *  We have to implement XPath 2.0 evaluations in order to support more complex XPath queries.
- *  For example, the following query is not supported:
- *  - "//o[@base and @ver]/concat(@base,'|',@ver)"
- *  When we implement XPath 2.0 evaluations, we should remove the @Disabled annotation from
- *  findsXpathWithFunctionThatReturnsSeveralItems test.
  */
 @SuppressWarnings({"PMD.TooManyMethods", "PMD.DoNotUseThreads"})
 final class XMLDocumentTest {
@@ -412,18 +406,6 @@ final class XMLDocumentTest {
         MatcherAssert.assertThat(
             root.xpath("//z9/@a").get(0),
             Matchers.equalTo("433")
-        );
-    }
-
-    @Test
-    @Disabled
-    void findsXpathWithFunctionThatReturnsSeveralItems() {
-        MatcherAssert.assertThat(
-            "XMLDocument can handle XPath 2.0 feature - XPath evaluation of concat method, but it can't",
-            new XMLDocument(
-                "<o><o base='a' ver='1'/><o base='b' ver='2'/></o>"
-            ).xpath("//o[@base and @ver]/concat(@base,'|',@ver)"),
-            Matchers.hasItems("a|1", "b|2")
         );
     }
 }


### PR DESCRIPTION
Add the `SaxonDocument` implementation of `XML` interface to enable `XPath 2.0` features.

Closes: #213 