### PR TITLE
bug: indentify the bug with XMLDocument comparison

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,26 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
           <source>8</source>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <configuration>
+          <!--
+            @todo #1:90min Enable Groovy Integration Test
+             The Groovy integration test is disabled because it fails.
+             The problem is that the XMLDocument#equals method is
+             indentation-aware, but it shouldn't be.
+             We need to fix it and enable the test.
+          -->
+          <pomExcludes>groovy/pom.xml</pomExcludes>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>${project.artifactId}</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/src/it/groovy/README.md
+++ b/src/it/groovy/README.md
@@ -1,0 +1,12 @@
+# Groovy Integration Test
+
+This module contains integration tests for `jcabi-xml` usage in Groovy scripts.
+
+To run the tests, execute the following command:
+
+```shell
+mvn clean integration-test invoker:run -Dinvoker.test=groovy -DskipTests
+```
+
+The testing Groovy code you can find in the [verify.groovy](verify.groovy)
+script.

--- a/src/it/groovy/first.xmir
+++ b/src/it/groovy/first.xmir
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<program>
+  <indentation/>
+</program>

--- a/src/it/groovy/invoker.properties
+++ b/src/it/groovy/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean

--- a/src/it/groovy/pom.xml
+++ b/src/it/groovy/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2012-2022, jcabi.com
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met: 1) Redistributions of source code must retain the above
+copyright notice, this list of conditions and the following
+disclaimer. 2) Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution. 3) Neither the name of the jcabi.com nor
+the names of its contributors may be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.jcabi</groupId>
+    <artifactId>jcabi</artifactId>
+    <version>1.39.0</version>
+  </parent>
+  <groupId>com.jcabi.xml</groupId>
+  <artifactId>groovy</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>@project.artifactId@</artifactId>
+      <version>@project.version@</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/groovy/same.xmir
+++ b/src/it/groovy/same.xmir
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<program>
+          <indentation/>
+</program>

--- a/src/it/groovy/verify.groovy
+++ b/src/it/groovy/verify.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2012-2022, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+import com.jcabi.xml.XMLDocument
+
+def log = new File(basedir, 'build.log')
+def fist = new XMLDocument(new File(basedir, 'first.xmir'))
+def same = new XMLDocument(new File(basedir, 'same.xmir'))
+
+assert fist == same
+
+assert log.text.contains("BUILD SUCCESS")

--- a/src/test/java/com/jcabi/xml/XMLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XMLDocumentTest.java
@@ -48,6 +48,7 @@ import org.cactoos.text.FormattedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -378,6 +379,20 @@ final class XMLDocumentTest {
             Matchers.not(
                 Matchers.equalTo(new XMLDocument("<hi><man>  </man></hi>"))
             )
+        );
+    }
+
+    @Test
+    @Disabled
+    void comparesDocumentsWithDifferentIndentations() {
+        // @todo #1:90min Implement comparison of XML documents with different indentations.
+        //  The current implementation of XMLDocument does not ignore different indentations
+        //  when comparing two XML documents. We need to implement a comparison that ignores
+        //  different indentations. Don't forget to remove the @Disabled annotation from this test.
+        MatcherAssert.assertThat(
+            "Different indentations should be ignored",
+            new XMLDocument("<program>\n <indentation/></program>"),
+            Matchers.equalTo(new XMLDocument("<program>\n  <indentation/></program>"))
         );
     }
 


### PR DESCRIPTION
I have faced with the problem of `XMLDocument` comparison. If I have two similar documents, but which use different formating they aren't equal. For example:
```xml
<program>
  <indentation/>
</program>
```
and
```
<program>
    <indentation/>
</program>
```
aren't equal `XMLDocuments`.

In this PR I added:

1. The unit test that reveals the problem with `XMLDocument` comparison
2. The integration test that uses `XMLDocument` in a Groovy script. 
