### PR TITLE
feat(#277): Add `#deepCopy` And `#inner()` Methods Instead of `Node`

### DIFF
--- a/src/main/java/com/jcabi/xml/DomParser.java
+++ b/src/main/java/com/jcabi/xml/DomParser.java
@@ -31,13 +31,9 @@ package com.jcabi.xml;
 
 import com.jcabi.log.Logger;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import javax.print.Doc;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -100,18 +96,33 @@ final class DomParser {
         this(fct, new BytesSource(bytes));
     }
 
-
+    /**
+     * Public ctor.
+     *
+     * <p>An {@link IllegalArgumentException} may be thrown if the parameter
+     * passed is not in XML format. It doesn't perform a strict validation
+     * and is not guaranteed that an exception will be thrown whenever
+     * the parameter is not XML.
+     *
+     * @param fct Document builder factory to use
+     * @param file The XML as a file
+     */
     DomParser(final DocumentBuilderFactory fct, final File file) {
         this(fct, new FileSource(file));
     }
 
+    /**
+     * Private ctor.
+     * @param factory Document builder factory to use
+     * @param source Source of XML
+     */
     private DomParser(final DocumentBuilderFactory factory, final DocSource source) {
         this.factory = factory;
         this.source = source;
     }
 
     /**
-     * Get document of body.
+     * Get the document body.
      * @return The document
      */
     public Document document() {
@@ -158,8 +169,19 @@ final class DomParser {
      */
     private interface DocSource {
 
+        /**
+         * Parse XML by the builder.
+         * @param builder The builder to use during parsing.
+         * @return The document.
+         * @throws IOException If fails.
+         * @throws SAXException If fails.
+         */
         Document apply(DocumentBuilder builder) throws IOException, SAXException;
 
+        /**
+         * The length of the source.
+         * @return The length.
+         */
         long length();
     }
 

--- a/src/main/java/com/jcabi/xml/DomParser.java
+++ b/src/main/java/com/jcabi/xml/DomParser.java
@@ -31,6 +31,7 @@ package com.jcabi.xml;
 
 import com.jcabi.log.Logger;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -100,10 +101,6 @@ final class DomParser {
     }
 
 
-    DomParser(final DocumentBuilderFactory fct, final InputStream stream) {
-        this(fct, new StreamSource(stream));
-    }
-
     DomParser(final DocumentBuilderFactory fct, final File file) {
         this(fct, new FileSource(file));
     }
@@ -155,6 +152,10 @@ final class DomParser {
         return doc;
     }
 
+    /**
+     * Source of XML.
+     * @since 0.32
+     */
     private interface DocSource {
 
         Document apply(DocumentBuilder builder) throws IOException, SAXException;
@@ -162,15 +163,22 @@ final class DomParser {
         long length();
     }
 
+    /**
+     * File source of XML from a file.
+     * @since 0.32
+     */
     private static class FileSource implements DocSource {
 
+        /**
+         * The file.
+         */
         private final File file;
 
-        private FileSource(final Path path) {
-            this(path.toFile());
-        }
-
-        private FileSource(final File file) {
+        /**
+         * Public ctor.
+         * @param file The file.
+         */
+        FileSource(final File file) {
             this.file = file;
         }
 
@@ -185,38 +193,30 @@ final class DomParser {
         }
     }
 
-
-    private static class StreamSource implements DocSource {
-
-        private final InputStream stream;
-
-        public StreamSource(final InputStream stream) {
-            this.stream = stream;
-        }
-
-        @Override
-        public Document apply(final DocumentBuilder builder) throws IOException, SAXException {
-            final Document res = builder.parse(this.stream);
-            this.stream.close();
-            return res;
-        }
-
-        @Override
-        public long length() {
-            return 0;
-        }
-    }
-
-
+    /**
+     * Bytes source of XML.
+     * @since 0.32
+     */
     private static class BytesSource implements DocSource {
 
+        /**
+         * Bytes of the XML.
+         */
         private final byte[] xml;
 
-        private BytesSource(final String xml) {
+        /**
+         * Public ctor.
+         * @param xml Bytes of the XML.
+         */
+        BytesSource(final String xml) {
             this(xml.getBytes(StandardCharsets.UTF_8));
         }
 
-        private BytesSource(final byte[] xml) {
+        /**
+         * Public ctor.
+         * @param xml Bytes of the XML.
+         */
+        BytesSource(final byte[] xml) {
             this.xml = xml;
         }
 
@@ -227,7 +227,7 @@ final class DomParser {
 
         @Override
         public long length() {
-            return xml.length;
+            return this.xml.length;
         }
     }
 }

--- a/src/main/java/com/jcabi/xml/DomParser.java
+++ b/src/main/java/com/jcabi/xml/DomParser.java
@@ -33,8 +33,10 @@ import com.jcabi.log.Logger;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import javax.print.Doc;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -95,6 +97,11 @@ final class DomParser {
     @SuppressWarnings("PMD.ArrayIsStoredDirectly")
     DomParser(final DocumentBuilderFactory fct, final byte[] bytes) {
         this(fct, new BytesSource(bytes));
+    }
+
+
+    DomParser(final DocumentBuilderFactory fct, final InputStream stream) {
+        this(fct, new StreamSource(stream));
     }
 
     DomParser(final DocumentBuilderFactory fct, final File file) {
@@ -175,6 +182,28 @@ final class DomParser {
         @Override
         public long length() {
             return this.file.length();
+        }
+    }
+
+
+    private static class StreamSource implements DocSource {
+
+        private final InputStream stream;
+
+        public StreamSource(final InputStream stream) {
+            this.stream = stream;
+        }
+
+        @Override
+        public Document apply(final DocumentBuilder builder) throws IOException, SAXException {
+            final Document res = builder.parse(this.stream);
+            this.stream.close();
+            return res;
+        }
+
+        @Override
+        public long length() {
+            return 0;
         }
     }
 

--- a/src/main/java/com/jcabi/xml/SaxonDocument.java
+++ b/src/main/java/com/jcabi/xml/SaxonDocument.java
@@ -200,7 +200,13 @@ public final class SaxonDocument implements XML {
         );
     }
 
-    @Override
+    /**
+     * Retrieve DOM node, represented by this wrapper.
+     * This method works exactly the same as {@link #deepCopy()}.
+     * @deprecated Use {@link #inner()} or {@link #deepCopy()} instead.
+     * @return Deep copy of the inner DOM node.
+     */
+    @Deprecated
     public Node node() {
         throw new UnsupportedOperationException(
             String.format(SaxonDocument.UNSUPPORTED, "node")

--- a/src/main/java/com/jcabi/xml/SaxonDocument.java
+++ b/src/main/java/com/jcabi/xml/SaxonDocument.java
@@ -207,6 +207,20 @@ public final class SaxonDocument implements XML {
     }
 
     @Override
+    public Node inner() {
+        throw new UnsupportedOperationException(
+            String.format(SaxonDocument.UNSUPPORTED, "inner")
+        );
+    }
+
+    @Override
+    public Node deepCopy() {
+        throw new UnsupportedOperationException(
+            String.format(SaxonDocument.UNSUPPORTED, "deepCopy")
+        );
+    }
+
+    @Override
     public Collection<SAXParseException> validate() {
         throw new UnsupportedOperationException(
             String.format(SaxonDocument.UNSUPPORTED, "validate")

--- a/src/main/java/com/jcabi/xml/SaxonDocument.java
+++ b/src/main/java/com/jcabi/xml/SaxonDocument.java
@@ -59,6 +59,7 @@ import org.xml.sax.SAXParseException;
  *
  * @since 0.28
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class SaxonDocument implements XML {
 
     /**

--- a/src/main/java/com/jcabi/xml/StrictXML.java
+++ b/src/main/java/com/jcabi/xml/StrictXML.java
@@ -158,7 +158,7 @@ public final class StrictXML implements XML {
 
     @Override
     public Node node() {
-        return this.origin.node();
+        return this.origin.deepCopy();
     }
 
     @Override
@@ -270,7 +270,7 @@ public final class StrictXML implements XML {
             validator.setErrorHandler(
                 new XMLDocument.ValidationHandler(errors)
             );
-            final DOMSource dom = new DOMSource(xml.node());
+            final DOMSource dom = new DOMSource(xml.inner());
             for (int retry = 1; retry <= max; ++retry) {
                 try {
                     validator.validate(dom);

--- a/src/main/java/com/jcabi/xml/StrictXML.java
+++ b/src/main/java/com/jcabi/xml/StrictXML.java
@@ -108,8 +108,10 @@ public final class StrictXML implements XML {
      * @param errors XML Document errors
      */
     @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
-    private StrictXML(final XML xml,
-        final Collection<SAXParseException> errors) {
+    private StrictXML(
+        final XML xml,
+        final Collection<SAXParseException> errors
+    ) {
         if (!errors.isEmpty()) {
             Logger.warn(
                 StrictXML.class,
@@ -160,6 +162,16 @@ public final class StrictXML implements XML {
     }
 
     @Override
+    public Node inner() {
+        return this.origin.inner();
+    }
+
+    @Override
+    public Node deepCopy() {
+        return this.origin.deepCopy();
+    }
+
+    @Override
     public Collection<SAXParseException> validate() {
         return this.origin.validate();
     }
@@ -185,7 +197,8 @@ public final class StrictXML implements XML {
      * @return List of messages to print
      */
     private static Iterable<String> print(
-        final Collection<SAXParseException> errors) {
+        final Collection<SAXParseException> errors
+    ) {
         final Collection<String> lines = new ArrayList<>(errors.size());
         for (final SAXParseException error : errors) {
             lines.add(StrictXML.asMessage(error));
@@ -248,7 +261,8 @@ public final class StrictXML implements XML {
      */
     private static Collection<SAXParseException> validate(
         final XML xml,
-        final Validator validator) {
+        final Validator validator
+    ) {
         final Collection<SAXParseException> errors =
             new CopyOnWriteArrayList<>();
         final int max = 3;

--- a/src/main/java/com/jcabi/xml/StrictXML.java
+++ b/src/main/java/com/jcabi/xml/StrictXML.java
@@ -156,7 +156,13 @@ public final class StrictXML implements XML {
         return this.origin.merge(context);
     }
 
-    @Override
+    /**
+     * Retrieve DOM node, represented by this wrapper.
+     * This method works exactly the same as {@link #deepCopy()}.
+     * @deprecated Use {@link #inner()} or {@link #deepCopy()} instead.
+     * @return Deep copy of the inner DOM node.
+     */
+    @Deprecated
     public Node node() {
         return this.origin.deepCopy();
     }

--- a/src/main/java/com/jcabi/xml/XML.java
+++ b/src/main/java/com/jcabi/xml/XML.java
@@ -165,7 +165,7 @@ public interface XML {
      * This method works exactly the same as {@link #deepCopy()}.
      * @return DOM node
      */
-    @Deprecated
+//    @Deprecated
     Node node();
 
     /**

--- a/src/main/java/com/jcabi/xml/XML.java
+++ b/src/main/java/com/jcabi/xml/XML.java
@@ -46,8 +46,8 @@ import org.xml.sax.SAXParseException;
  *   // ...
  * }</pre>
  *
- * <p>You can always get DOM node out of this abstraction using {@link #node()}
- * method.
+ * <p>You can always get DOM node out of this abstraction using {@link #inner()}
+ * or {@link #deepCopy()} methods.
  *
  * <p>{@code toString()} must produce a full XML.
  *
@@ -165,7 +165,7 @@ public interface XML {
      * This method works exactly the same as {@link #deepCopy()}.
      * @return DOM node
      */
-//    @Deprecated
+    @Deprecated
     Node node();
 
     /**

--- a/src/main/java/com/jcabi/xml/XML.java
+++ b/src/main/java/com/jcabi/xml/XML.java
@@ -161,9 +161,27 @@ public interface XML {
 
     /**
      * Retrieve DOM node, represented by this wrapper.
+     * This method is deprecated, use {@link #inner()} ()} and {@link #deepCopy()} methods instead.
+     * This method works exactly the same as {@link #deepCopy()}.
      * @return DOM node
      */
+    @Deprecated
     Node node();
+
+    /**
+     * Retrieve DOM node, represented by this wrapper.
+     * Pay attention that this method returns inner node, not a deep copy.
+     * It means that any changes to the returned node will affect the original XML.
+     * @return Inner node.
+     */
+    Node inner();
+
+    /**
+     * Retrieve a deep copy of the DOM node, represented by this wrapper.
+     * Might be expensive in terms of performance.
+     * @return Deep copy of the node.
+     */
+    Node deepCopy();
 
     /**
      * Validate this XML against the XSD schema inside it.

--- a/src/main/java/com/jcabi/xml/XML.java
+++ b/src/main/java/com/jcabi/xml/XML.java
@@ -161,9 +161,9 @@ public interface XML {
 
     /**
      * Retrieve DOM node, represented by this wrapper.
-     * This method is deprecated, use {@link #inner()} ()} and {@link #deepCopy()} methods instead.
      * This method works exactly the same as {@link #deepCopy()}.
-     * @return DOM node
+     * @deprecated Use {@link #inner()} or {@link #deepCopy()} instead.
+     * @return Deep copy of the inner DOM node.
      */
     @Deprecated
     Node node();

--- a/src/main/java/com/jcabi/xml/XMLDocument.java
+++ b/src/main/java/com/jcabi/xml/XMLDocument.java
@@ -184,6 +184,23 @@ public final class XMLDocument implements XML {
     }
 
     /**
+     * Public ctor, from XML in a file.
+     *
+     * <p>The object is created with a default implementation of
+     * {@link NamespaceContext}, which already defines a
+     * number of namespaces, see {@link XMLDocument#XMLDocument(String)}.
+     *
+     * <p>An {@link IllegalArgumentException} is thrown if the parameter
+     * passed is not in XML format.
+     *
+     * @param file XML file
+     * @throws FileNotFoundException In case of I/O problems
+     */
+    public XMLDocument(final Path file) throws FileNotFoundException {
+        this(new DomParser(XMLDocument.configuredDFactory(), file.toFile()).document());
+    }
+
+    /**
      * Public ctor, from input stream.
      *
      * <p>The object is created with a default implementation of
@@ -201,24 +218,8 @@ public final class XMLDocument implements XML {
      */
     @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
     public XMLDocument(final InputStream stream) throws IOException {
-        this(new DomParser(XMLDocument.configuredDFactory(), stream).document());
-    }
-
-    /**
-     * Public ctor, from XML in a file.
-     *
-     * <p>The object is created with a default implementation of
-     * {@link NamespaceContext}, which already defines a
-     * number of namespaces, see {@link XMLDocument#XMLDocument(String)}.
-     *
-     * <p>An {@link IllegalArgumentException} is thrown if the parameter
-     * passed is not in XML format.
-     *
-     * @param file XML file
-     * @throws FileNotFoundException In case of I/O problems
-     */
-    public XMLDocument(final Path file) throws FileNotFoundException {
-        this(new DomParser(XMLDocument.configuredDFactory(), file.toFile()).document());
+        this(new TextResource(stream).toString());
+        stream.close();
     }
 
     /**

--- a/src/main/java/com/jcabi/xml/XMLDocument.java
+++ b/src/main/java/com/jcabi/xml/XMLDocument.java
@@ -68,6 +68,7 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+import net.sf.saxon.trans.SymbolicName;
 import net.sf.saxon.xpath.XPathFactoryImpl;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -126,7 +127,7 @@ public final class XMLDocument implements XML {
      */
     public XMLDocument(final String text) {
         this(
-            new DomParser(XMLDocument.configuredDFactory(), text).document(),
+            new DomParser(FACTORY, text).document(),
             new XPathContext(),
             false
         );
@@ -152,7 +153,7 @@ public final class XMLDocument implements XML {
      */
     public XMLDocument(final byte[] data) {
         this(
-            new DomParser(XMLDocument.configuredDFactory(), data).document(),
+            new DomParser(FACTORY, data).document(),
             new XPathContext(),
             false
         );
@@ -202,8 +203,8 @@ public final class XMLDocument implements XML {
      * @throws FileNotFoundException In case of I/O problems
      */
     public XMLDocument(final File file) throws FileNotFoundException {
-        this(new TextResource(file).toString());
-//        this(new DomParser(XMLDocument.configuredDFactory(), file).document());
+//        this(new TextResource(file).toString());
+        this(new DomParser(FACTORY, file).document());
     }
 
     /**
@@ -322,7 +323,8 @@ public final class XMLDocument implements XML {
         final Node casted = this.cache;
         final Node answer;
         if (casted instanceof Document) {
-            answer = casted.cloneNode(true);
+            answer = casted;
+//            answer = casted.cloneNode(true);
         } else {
             answer = XMLDocument.createImportedNode(casted);
         }
@@ -478,7 +480,7 @@ public final class XMLDocument implements XML {
      * @return A cloned node imported in a dedicated document.
      */
     private static Node createImportedNode(final Node node) {
-        final DocumentBuilderFactory factory = XMLDocument.configuredDFactory();
+        final DocumentBuilderFactory factory = FACTORY;
         final DocumentBuilder builder;
         try {
             builder = factory.newDocumentBuilder();
@@ -598,6 +600,8 @@ public final class XMLDocument implements XML {
         }
         return result.getNode();
     }
+
+    private static final DocumentBuilderFactory FACTORY = XMLDocument.configuredDFactory();
 
     /**
      * Create new {@link DocumentBuilderFactory} and configure it.

--- a/src/main/java/com/jcabi/xml/XMLDocument.java
+++ b/src/main/java/com/jcabi/xml/XMLDocument.java
@@ -308,7 +308,13 @@ public final class XMLDocument implements XML {
         return this.cache.hashCode();
     }
 
-    @Override
+    /**
+     * Retrieve DOM node, represented by this wrapper.
+     * This method works exactly the same as {@link #deepCopy()}.
+     * @deprecated Use {@link #inner()} or {@link #deepCopy()} instead.
+     * @return Deep copy of the inner DOM node.
+     */
+    @Deprecated
     public Node node() {
         return this.deepCopy();
     }

--- a/src/main/java/com/jcabi/xml/XMLDocument.java
+++ b/src/main/java/com/jcabi/xml/XMLDocument.java
@@ -68,7 +68,6 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
-import net.sf.saxon.trans.SymbolicName;
 import net.sf.saxon.xpath.XPathFactoryImpl;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -323,12 +322,21 @@ public final class XMLDocument implements XML {
         final Node casted = this.cache;
         final Node answer;
         if (casted instanceof Document) {
-            answer = casted;
-//            answer = casted.cloneNode(true);
+            answer = casted.cloneNode(true);
         } else {
             answer = XMLDocument.createImportedNode(casted);
         }
         return answer;
+    }
+
+    @Override
+    public Node inner() {
+        return this.cache;
+    }
+
+    @Override
+    public Node deepCopy() {
+        return this.node();
     }
 
     @Override

--- a/src/main/java/com/jcabi/xml/XMLDocument.java
+++ b/src/main/java/com/jcabi/xml/XMLDocument.java
@@ -310,14 +310,7 @@ public final class XMLDocument implements XML {
 
     @Override
     public Node node() {
-        final Node casted = this.cache;
-        final Node answer;
-        if (casted instanceof Document) {
-            answer = casted.cloneNode(true);
-        } else {
-            answer = XMLDocument.createImportedNode(casted);
-        }
-        return answer;
+        return this.deepCopy();
     }
 
     @Override
@@ -327,7 +320,14 @@ public final class XMLDocument implements XML {
 
     @Override
     public Node deepCopy() {
-        return this.node();
+        final Node casted = this.cache;
+        final Node answer;
+        if (casted instanceof Document) {
+            answer = casted.cloneNode(true);
+        } else {
+            answer = XMLDocument.createImportedNode(casted);
+        }
+        return answer;
     }
 
     @Override

--- a/src/main/java/com/jcabi/xml/XMLDocument.java
+++ b/src/main/java/com/jcabi/xml/XMLDocument.java
@@ -107,6 +107,22 @@ public final class XMLDocument implements XML {
     private final transient Node cache;
 
     /**
+     * Public ctor, from a source.
+     *
+     * <p>The object is created with a default implementation of
+     * {@link NamespaceContext}, which already defines a
+     * number of namespaces, see {@link XMLDocument#XMLDocument(String)}.
+     *
+     * <p>An {@link IllegalArgumentException} is thrown if the parameter
+     * passed is not in XML format.
+     *
+     * @param source Source of XML document
+     */
+    public XMLDocument(final Source source) {
+        this(XMLDocument.transform(source));
+    }
+
+    /**
      * Public ctor, from XML as a text.
      *
      * <p>The object is created with a default implementation of
@@ -125,11 +141,7 @@ public final class XMLDocument implements XML {
      * @param text XML document body
      */
     public XMLDocument(final String text) {
-        this(
-            new DomParser(FACTORY, text).document(),
-            new XPathContext(),
-            false
-        );
+        this(new DomParser(XMLDocument.configuredDFactory(), text).document());
     }
 
     /**
@@ -151,41 +163,7 @@ public final class XMLDocument implements XML {
      * @param data The XML body
      */
     public XMLDocument(final byte[] data) {
-        this(
-            new DomParser(FACTORY, data).document(),
-            new XPathContext(),
-            false
-        );
-    }
-
-    /**
-     * Public ctor, from a DOM node.
-     *
-     * <p>The object is created with a default implementation of
-     * {@link NamespaceContext}, which already defines a
-     * number of namespaces, see {@link XMLDocument#XMLDocument(String)}.
-     *
-     * @param node DOM source
-     * @since 0.2
-     */
-    public XMLDocument(final Node node) {
-        this(node, new XPathContext(), !(node instanceof Document));
-    }
-
-    /**
-     * Public ctor, from a source.
-     *
-     * <p>The object is created with a default implementation of
-     * {@link NamespaceContext}, which already defines a
-     * number of namespaces, see {@link XMLDocument#XMLDocument(String)}.
-     *
-     * <p>An {@link IllegalArgumentException} is thrown if the parameter
-     * passed is not in XML format.
-     *
-     * @param source Source of XML document
-     */
-    public XMLDocument(final Source source) {
-        this(XMLDocument.transform(source), new XPathContext(), false);
+        this(new DomParser(XMLDocument.configuredDFactory(), data).document());
     }
 
     /**
@@ -202,8 +180,28 @@ public final class XMLDocument implements XML {
      * @throws FileNotFoundException In case of I/O problems
      */
     public XMLDocument(final File file) throws FileNotFoundException {
-//        this(new TextResource(file).toString());
-        this(new DomParser(FACTORY, file).document());
+        this(new DomParser(XMLDocument.configuredDFactory(), file).document());
+    }
+
+    /**
+     * Public ctor, from input stream.
+     *
+     * <p>The object is created with a default implementation of
+     * {@link NamespaceContext}, which already defines a
+     * number of namespaces, see {@link XMLDocument#XMLDocument(String)}.
+     *
+     * <p>An {@link IllegalArgumentException} is thrown if the parameter
+     * passed is not in XML format.
+     *
+     * <p>The provided input stream will be closed automatically after
+     * getting data from it.
+     *
+     * @param stream The input stream, which will be closed automatically
+     * @throws IOException In case of I/O problem
+     */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+    public XMLDocument(final InputStream stream) throws IOException {
+        this(new DomParser(XMLDocument.configuredDFactory(), stream).document());
     }
 
     /**
@@ -220,7 +218,7 @@ public final class XMLDocument implements XML {
      * @throws FileNotFoundException In case of I/O problems
      */
     public XMLDocument(final Path file) throws FileNotFoundException {
-        this(file.toFile());
+        this(new DomParser(XMLDocument.configuredDFactory(), file.toFile()).document());
     }
 
     /**
@@ -258,25 +256,17 @@ public final class XMLDocument implements XML {
     }
 
     /**
-     * Public ctor, from input stream.
+     * Public ctor, from a DOM node.
      *
      * <p>The object is created with a default implementation of
      * {@link NamespaceContext}, which already defines a
      * number of namespaces, see {@link XMLDocument#XMLDocument(String)}.
      *
-     * <p>An {@link IllegalArgumentException} is thrown if the parameter
-     * passed is not in XML format.
-     *
-     * <p>The provided input stream will be closed automatically after
-     * getting data from it.
-     *
-     * @param stream The input stream, which will be closed automatically
-     * @throws IOException In case of I/O problem
+     * @param node DOM source
+     * @since 0.2
      */
-    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
-    public XMLDocument(final InputStream stream) throws IOException {
-        this(new TextResource(stream).toString());
-        stream.close();
+    public XMLDocument(final Node node) {
+        this(node, new XPathContext(), !(node instanceof Document));
     }
 
     /**
@@ -488,7 +478,7 @@ public final class XMLDocument implements XML {
      * @return A cloned node imported in a dedicated document.
      */
     private static Node createImportedNode(final Node node) {
-        final DocumentBuilderFactory factory = FACTORY;
+        final DocumentBuilderFactory factory = XMLDocument.configuredDFactory();
         final DocumentBuilder builder;
         try {
             builder = factory.newDocumentBuilder();
@@ -608,8 +598,6 @@ public final class XMLDocument implements XML {
         }
         return result.getNode();
     }
-
-    private static final DocumentBuilderFactory FACTORY = XMLDocument.configuredDFactory();
 
     /**
      * Create new {@link DocumentBuilderFactory} and configure it.

--- a/src/main/java/com/jcabi/xml/XMLDocument.java
+++ b/src/main/java/com/jcabi/xml/XMLDocument.java
@@ -203,6 +203,7 @@ public final class XMLDocument implements XML {
      */
     public XMLDocument(final File file) throws FileNotFoundException {
         this(new TextResource(file).toString());
+//        this(new DomParser(XMLDocument.configuredDFactory(), file).document());
     }
 
     /**

--- a/src/main/java/com/jcabi/xml/XSLDocument.java
+++ b/src/main/java/com/jcabi/xml/XSLDocument.java
@@ -434,7 +434,7 @@ public final class XSLDocument implements XSL {
         trans.setErrorListener(errors);
         final long start = System.nanoTime();
         try {
-            trans.transform(new DOMSource(xml.node()), result);
+            trans.transform(new DOMSource(xml.inner()), result);
         } catch (final TransformerException ex) {
             final StringBuilder summary = new StringBuilder(
                 String.join("; ", errors.summary())

--- a/src/test/java/com/jcabi/xml/XMLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XMLDocumentTest.java
@@ -682,6 +682,7 @@ final class XMLDocumentTest {
 
 
     @Test
+    @Disabled
     void createsManyXmlDocuments() throws ParserConfigurationException, IOException, SAXException {
         final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         String xml = this.large();
@@ -721,6 +722,7 @@ final class XMLDocumentTest {
 
     // ~ 1.6
     @RepeatedTest(10)
+    @Disabled
     void createsXmlFromFile(
         @TempDir final Path temp
     ) throws IOException, ParserConfigurationException, SAXException {

--- a/src/test/java/com/jcabi/xml/XMLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XMLDocumentTest.java
@@ -63,6 +63,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
@@ -718,7 +719,8 @@ final class XMLDocumentTest {
     }
 
 
-    @Test
+   // ~ 1.6
+    @RepeatedTest(10)
     void createsXmlFromFile(
         @TempDir final Path temp
     ) throws IOException, ParserConfigurationException, SAXException {
@@ -737,10 +739,9 @@ final class XMLDocumentTest {
             );
         }
         final long endSimple = System.nanoTime();
+        final double simple = (endSimple - startSimple) / 1_000_000.0d;
         System.out.println(
-            "Default approach to create XML timing: " + (endSimple - startSimple) / 1_000_000 + " ms");
-
-        Logger.info(this, "Time: %[ms]s", (endSimple - startSimple) / 1000);
+            "Default approach to create XML timing: " + simple + " ms");
         final long start = System.nanoTime();
         for (int i = 0; i < 10_000; ++i) {
             final String actual = new XMLDocument(xml).node()
@@ -751,9 +752,14 @@ final class XMLDocumentTest {
             );
         }
         final long end = System.nanoTime();
+        final double actual = (end - start) / 1_000_000.0d;
         System.out.println(
-            "jcabi-xml approach to create XML timing: " + (end - start) / 1_000_000 + " ms"
+            "jcabi-xml approach to create XML timing: " + actual + " ms"
         );
+        System.out.println(
+            "Simple approach is " + (actual / simple) + " times faster"
+        );
+
     }
 
     private String large() {

--- a/src/test/java/com/jcabi/xml/XMLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XMLDocumentTest.java
@@ -719,7 +719,7 @@ final class XMLDocumentTest {
     }
 
 
-   // ~ 1.6
+    // ~ 1.6
     @RepeatedTest(10)
     void createsXmlFromFile(
         @TempDir final Path temp
@@ -772,7 +772,7 @@ final class XMLDocumentTest {
             "<credit>test-2</credit>",
             "</payment>"
         );
-        IntStream.range(0, 100).mapToObj(i -> payment).forEach(builder::append);
+        IntStream.range(0, 1_000).mapToObj(i -> payment).forEach(builder::append);
         return builder.append("</root>").toString();
     }
 

--- a/src/test/java/com/jcabi/xml/XMLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XMLDocumentTest.java
@@ -190,7 +190,7 @@ final class XMLDocumentTest {
             new XMLDocument(
                 new XMLDocument(
                     "<z xmlns:a='hey'><f a:boom='test'/></z>"
-                ).node()
+                ).inner()
             ).toString(),
             Matchers.containsString("a:boom")
         );
@@ -202,11 +202,11 @@ final class XMLDocumentTest {
             this.getClass().getResource("simple.xml")
         );
         MatcherAssert.assertThat(
-            doc.nodes("/root/simple").get(0).node().getNodeName(),
+            doc.nodes("/root/simple").get(0).inner().getNodeName(),
             Matchers.equalTo("simple")
         );
         MatcherAssert.assertThat(
-            doc.nodes("//simple").get(0).node().getNodeType(),
+            doc.nodes("//simple").get(0).inner().getNodeType(),
             Matchers.equalTo(Node.ELEMENT_NODE)
         );
     }
@@ -392,7 +392,7 @@ final class XMLDocumentTest {
         final Runnable runnable = () -> {
             try {
                 MatcherAssert.assertThat(
-                    new XMLDocument(xml.node()).toString(),
+                    new XMLDocument(xml.inner()).toString(),
                     Matchers.containsString(">5555<")
                 );
                 done.incrementAndGet();
@@ -434,11 +434,11 @@ final class XMLDocumentTest {
     void buildsDomNode() {
         final XML doc = new XMLDocument("<?xml version='1.0'?><f/>");
         MatcherAssert.assertThat(
-            doc.node(),
+            doc.inner(),
             Matchers.instanceOf(Document.class)
         );
         MatcherAssert.assertThat(
-            doc.nodes("/f").get(0).node(),
+            doc.nodes("/f").get(0).inner(),
             Matchers.instanceOf(Element.class)
         );
     }
@@ -486,7 +486,7 @@ final class XMLDocumentTest {
     @Test
     void preservesImmutability() {
         final XML xml = new XMLDocument("<r1><a/></r1>");
-        final Node node = xml.nodes("/r1/a").get(0).node();
+        final Node node = xml.nodes("/r1/a").get(0).deepCopy();
         node.appendChild(node.getOwnerDocument().createElement("h9"));
         MatcherAssert.assertThat(
             xml,


### PR DESCRIPTION
In this PR I:
1. Added two more methods to the `XML` interface
1.1. `#inner()` - returns inner node without copying.
1.2. `#deepCopy()` - returns the copy of the inner node.
2. Optimized `XMLDocument` constructors to avoid redundant copy operations on XML.

Closes to #277.

