### PR TITLE
bug(#300): re-throw compile-time and runtime warnings in `XSLDocument`

### DIFF
--- a/src/main/java/com/jcabi/xml/ConsoleErrorListener.java
+++ b/src/main/java/com/jcabi/xml/ConsoleErrorListener.java
@@ -25,36 +25,30 @@ final class ConsoleErrorListener implements ErrorListener {
         new CopyOnWriteArrayList<>();
 
     @Override
-    public void warning(final TransformerException warning)
-        throws TransformerException {
+    public void warning(final TransformerException warning) {
         Logger.warn(
             this, "#warning(): %s",
             warning.getMessageAndLocation()
         );
         this.errors.add(warning.getMessageAndLocation());
-        throw warning;
     }
 
     @Override
-    public void error(final TransformerException error)
-        throws TransformerException {
+    public void error(final TransformerException error) {
         Logger.error(
             this, "#error(): %s",
             error.getMessageAndLocation()
         );
         this.errors.add(error.getMessageAndLocation());
-        throw error;
     }
 
     @Override
-    public void fatalError(final TransformerException error)
-        throws TransformerException {
+    public void fatalError(final TransformerException error) {
         Logger.error(
             this, "#fatalError(): %s",
             error.getMessageAndLocation()
         );
         this.errors.add(error.getMessageAndLocation());
-        throw error;
     }
 
     /**

--- a/src/main/java/com/jcabi/xml/ConsoleErrorListener.java
+++ b/src/main/java/com/jcabi/xml/ConsoleErrorListener.java
@@ -25,12 +25,14 @@ final class ConsoleErrorListener implements ErrorListener {
         new CopyOnWriteArrayList<>();
 
     @Override
-    public void warning(final TransformerException warning) {
+    public void warning(final TransformerException warning)
+        throws TransformerException {
         Logger.warn(
             this, "#warning(): %s",
             warning.getMessageAndLocation()
         );
         this.errors.add(warning.getMessageAndLocation());
+        throw warning;
     }
 
     @Override

--- a/src/main/java/com/jcabi/xml/XSLDocument.java
+++ b/src/main/java/com/jcabi/xml/XSLDocument.java
@@ -441,6 +441,8 @@ public final class XSLDocument implements XSL {
      */
     private Transformer transformer() {
         final TransformerFactory factory = TransformerFactory.newInstance();
+        final ConsoleErrorListener errors = new ConsoleErrorListener();
+        factory.setErrorListener(errors);
         factory.setURIResolver(this.sources);
         final Transformer trans;
         try {
@@ -458,6 +460,15 @@ public final class XSLDocument implements XSL {
         }
         for (final Map.Entry<String, Object> ent : this.params.entrySet()) {
             trans.setParameter(ent.getKey(), ent.getValue());
+        }
+        if (!errors.summary().isEmpty()) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Failed to compile stylesheet by %s: %s",
+                    trans.getClass().getName(),
+                    errors.summary()
+                )
+            );
         }
         return trans;
     }

--- a/src/test/java/com/jcabi/xml/XSLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XSLDocumentTest.java
@@ -9,6 +9,7 @@ import com.yegor256.Together;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import javax.xml.transform.TransformerException;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -180,6 +181,25 @@ final class XSLDocumentTest {
             Matchers.allOf(
                 Matchers.containsString("Processing terminated by xsl:message"),
                 Matchers.containsString("by xsl:message at line 1 in foo")
+            )
+        );
+    }
+
+    @Test
+    void catchesXslWarnings() {
+        MatcherAssert.assertThat(
+            Assertions.assertThrows(
+                RuntimeException.class,
+                () ->
+                    new XSLDocument(this.getClass().getResourceAsStream("multiple-imports.xsl"))
+                        .with(new ClasspathSources(this.getClass()))
+                        .transform(new XMLDocument("<f/>"))
+            ).getLocalizedMessage(),
+            Matchers.allOf(
+                Matchers.containsString("Warning at xsl:stylesheet on line 31 column 139"),
+                Matchers.containsString(
+                    "Stylesheet module file:/second.xsl is included or imported more than once"
+                )
             )
         );
     }

--- a/src/test/java/com/jcabi/xml/XSLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XSLDocumentTest.java
@@ -9,7 +9,6 @@ import com.yegor256.Together;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import javax.xml.transform.TransformerException;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -186,7 +185,7 @@ final class XSLDocumentTest {
     }
 
     @Test
-    void catchesXslWarnings() {
+    void catchesXslWarningsDuringCompilation() {
         MatcherAssert.assertThat(
             Assertions.assertThrows(
                 RuntimeException.class,
@@ -196,7 +195,6 @@ final class XSLDocumentTest {
                         .transform(new XMLDocument("<f/>"))
             ).getLocalizedMessage(),
             Matchers.allOf(
-                Matchers.containsString("Warning at xsl:stylesheet on line 31 column 139"),
                 Matchers.containsString(
                     "Stylesheet module file:/second.xsl is included or imported more than once"
                 )

--- a/src/test/java/com/jcabi/xml/XSLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XSLDocumentTest.java
@@ -192,7 +192,8 @@ final class XSLDocumentTest {
                 () ->
                     new XSLDocument(this.getClass().getResourceAsStream("multiple-imports.xsl"))
                         .with(new ClasspathSources(this.getClass()))
-                        .transform(new XMLDocument("<f/>"))
+                        .transform(new XMLDocument("<f/>")),
+                "Warnings was not thrown, but they should"
             ).getLocalizedMessage(),
             Matchers.allOf(
                 Matchers.containsString(

--- a/src/test/resources/com/jcabi/xml/multiple-imports.xsl
+++ b/src/test/resources/com/jcabi/xml/multiple-imports.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2025 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:j="http://www.jcabi.com" version="2.0" exclude-result-prefixes="j">
+  <xsl:import href="second.xsl"/>
+  <xsl:import href="second.xsl"/>
+  <xsl:template match="/">
+    <result>
+      <xsl:call-template name="j:format">
+        <xsl:with-param name="value" select="5.67"/>
+      </xsl:call-template>
+    </result>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
In this PR I've updated `XSLDocument#transformer()` to catch warnings during XSL compilation, also, updated `ConsoleErrorListener#warning()` to throw warnings, if they are found.

closes #300
History:
- **bug(#300): test case**
- **bug(#300): catch compile**
- **bug(#300): throw warning**
