### PR TITLE
#119: implement LSInput contract on ClasspathInput

### DIFF
--- a/src/main/java/com/jcabi/xml/ClasspathInput.java
+++ b/src/main/java/com/jcabi/xml/ClasspathInput.java
@@ -6,6 +6,7 @@ package com.jcabi.xml;
 
 import java.io.InputStream;
 import java.io.Reader;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.TextOf;
@@ -29,13 +30,43 @@ final class ClasspathInput implements LSInput {
     private transient String systemid;
 
     /**
+     * Base URI.
+     */
+    private transient String baseuri;
+
+    /**
+     * Encoding to use when reading the resource.
+     */
+    private transient String encoding;
+
+    /**
+     * Whether the input source is certified.
+     */
+    private transient boolean certified;
+
+    /**
      * Constructor.
      * @param pubid Public id
      * @param sysid System id
      */
     ClasspathInput(final String pubid, final String sysid) {
+        this(pubid, sysid, null, null);
+    }
+
+    /**
+     * Constructor.
+     * @param pubid Public id
+     * @param sysid System id
+     * @param enc Encoding to use when reading the resource
+     * @param base Base URI
+     * @checkstyle ParameterNumberCheck (3 lines)
+     */
+    ClasspathInput(final String pubid, final String sysid,
+        final String enc, final String base) {
         this.publicid = pubid;
         this.systemid = sysid;
+        this.encoding = enc;
+        this.baseuri = base;
     }
 
     @Override
@@ -60,7 +91,7 @@ final class ClasspathInput implements LSInput {
 
     @Override
     public String getBaseURI() {
-        return null;
+        return this.baseuri;
     }
 
     @Override
@@ -71,7 +102,7 @@ final class ClasspathInput implements LSInput {
     @Override
     @SuppressWarnings("PMD.BooleanGetMethodName")
     public boolean getCertifiedText() {
-        return false;
+        return this.certified;
     }
 
     @Override
@@ -81,7 +112,7 @@ final class ClasspathInput implements LSInput {
 
     @Override
     public String getEncoding() {
-        return null;
+        return this.encoding;
     }
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
@@ -100,7 +131,7 @@ final class ClasspathInput implements LSInput {
                         );
                     }
                 ),
-                StandardCharsets.UTF_8
+                this.charset()
             ).asString();
             // @checkstyle IllegalCatchCheck (1 line)
         } catch (final Exception ex) {
@@ -115,32 +146,52 @@ final class ClasspathInput implements LSInput {
     }
 
     @Override
-    public void setBaseURI(final String baseuri) {
-        // intentionally empty
+    public void setBaseURI(final String base) {
+        this.baseuri = base;
     }
 
     @Override
     public void setByteStream(final InputStream bytestream) {
-        // intentionally empty
+        throw new UnsupportedOperationException(
+            "ClasspathInput resolves data from the classpath; setByteStream() is not supported"
+        );
     }
 
     @Override
-    public void setCertifiedText(final boolean certifiedtext) {
-        // intentionally empty
+    public void setCertifiedText(final boolean text) {
+        this.certified = text;
     }
 
     @Override
-    public void setCharacterStream(final Reader characterstream) {
-        // intentionally empty
+    public void setCharacterStream(final Reader stream) {
+        throw new UnsupportedOperationException(
+            "ClasspathInput resolves data from the classpath; setCharacterStream() is not supported"
+        );
     }
 
     @Override
-    public void setEncoding(final String encoding) {
-        // intentionally empty
+    public void setEncoding(final String enc) {
+        this.encoding = enc;
     }
 
     @Override
-    public void setStringData(final String stringdata) {
-        // intentionally empty
+    public void setStringData(final String data) {
+        throw new UnsupportedOperationException(
+            "ClasspathInput resolves data from the classpath; setStringData() is not supported"
+        );
+    }
+
+    /**
+     * Charset to use when reading the resource.
+     * @return Charset, or UTF-8 if no encoding was set
+     */
+    private Charset charset() {
+        final Charset cset;
+        if (this.encoding == null) {
+            cset = StandardCharsets.UTF_8;
+        } else {
+            cset = Charset.forName(this.encoding);
+        }
+        return cset;
     }
 }

--- a/src/main/java/com/jcabi/xml/ClasspathResolver.java
+++ b/src/main/java/com/jcabi/xml/ClasspathResolver.java
@@ -28,7 +28,7 @@ public final class ClasspathResolver implements LSResourceResolver {
         LSInput input = null;
         final ClassLoader loader = Thread.currentThread().getContextClassLoader();
         if (sid != null && loader.getResource(sid) != null) {
-            input = new ClasspathInput(pid, sid);
+            input = new ClasspathInput(pid, sid, null, base);
         }
         return input;
     }

--- a/src/test/java/com/jcabi/xml/ClasspathInputTest.java
+++ b/src/test/java/com/jcabi/xml/ClasspathInputTest.java
@@ -6,6 +6,7 @@ package com.jcabi.xml;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.ls.LSInput;
 
@@ -14,15 +15,95 @@ import org.w3c.dom.ls.LSInput;
  * @since 0.17.3
  */
 final class ClasspathInputTest {
+    /**
+     * Path of an XML resource available on the classpath in tests.
+     */
+    private static final String RESOURCE = "com/jcabi/xml/simple.xml";
+
     @Test
     void readsStringFromResourceSuccessfully() {
         final LSInput input = new ClasspathInput(
-            "Id", "com/jcabi/xml/simple.xml"
+            "Id", ClasspathInputTest.RESOURCE
         );
         MatcherAssert.assertThat(
             "Input XML does not contains expected string, but it should",
             input.getStringData(),
             Matchers.containsString("<root>")
+        );
+    }
+
+    @Test
+    void roundTripsBaseUri() {
+        final LSInput input = new ClasspathInput(
+            "Id", ClasspathInputTest.RESOURCE
+        );
+        input.setBaseURI("http://example.com/base");
+        MatcherAssert.assertThat(
+            "BaseURI set on the input should be returned by getBaseURI()",
+            input.getBaseURI(),
+            Matchers.equalTo("http://example.com/base")
+        );
+    }
+
+    @Test
+    void roundTripsEncoding() {
+        final LSInput input = new ClasspathInput(
+            "Id", ClasspathInputTest.RESOURCE
+        );
+        input.setEncoding("ISO-8859-1");
+        MatcherAssert.assertThat(
+            "Encoding set on the input should be returned by getEncoding()",
+            input.getEncoding(),
+            Matchers.equalTo("ISO-8859-1")
+        );
+    }
+
+    @Test
+    void roundTripsCertifiedText() {
+        final LSInput input = new ClasspathInput(
+            "Id", ClasspathInputTest.RESOURCE
+        );
+        input.setCertifiedText(true);
+        MatcherAssert.assertThat(
+            "CertifiedText set to true should be returned by getCertifiedText()",
+            input.getCertifiedText(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void rejectsByteStreamMutation() {
+        final LSInput input = new ClasspathInput(
+            "Id", ClasspathInputTest.RESOURCE
+        );
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> input.setByteStream(null),
+            "Setting a byte stream on a classpath-resolved input is meaningless"
+        );
+    }
+
+    @Test
+    void rejectsCharacterStreamMutation() {
+        final LSInput input = new ClasspathInput(
+            "Id", ClasspathInputTest.RESOURCE
+        );
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> input.setCharacterStream(null),
+            "Setting a character stream on a classpath-resolved input is meaningless"
+        );
+    }
+
+    @Test
+    void rejectsStringDataMutation() {
+        final LSInput input = new ClasspathInput(
+            "Id", ClasspathInputTest.RESOURCE
+        );
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> input.setStringData("anything"),
+            "Setting string data on a classpath-resolved input is meaningless"
         );
     }
 }


### PR DESCRIPTION
@yegor256 closes #119.

Reproduces the bug with six new failing tests in `ClasspathInputTest`, then fixes `ClasspathInput` to honour the `LSInput` contract.

### What was broken

`ClasspathInput` implements `org.w3c.dom.ls.LSInput`, but most of its setters and getters did nothing useful:

* `setBaseURI` / `getBaseURI` did not round-trip — `getBaseURI` always returned `null`.
* `setEncoding` / `getEncoding` did not round-trip — `getEncoding` always returned `null`, and `getStringData()` always read the resource as UTF-8 regardless of what the caller asked for.
* `setCertifiedText` / `getCertifiedText` did not round-trip — `getCertifiedText` always returned `false`.
* `setByteStream`, `setCharacterStream` and `setStringData` silently dropped the value the caller passed in, so callers had no way to know their request was a no-op.

### Fix

* Store `baseURI`, `encoding` and `certifiedText` in fields and round them through their getter/setter pairs.
* Use the configured `encoding` (when set) inside `getStringData()`, falling back to UTF-8.
* For the three setters that have no meaning on a classpath-resolved input — `setByteStream`, `setCharacterStream`, `setStringData` — throw `UnsupportedOperationException` with a descriptive message instead of silently dropping the call. This matches the suggestion in the issue and surfaces caller mistakes loudly.
* Keep `getCharacterStream()` and `getByteStream()` returning `null` so XML validators fall back to `getStringData()` as before.
* Wire `ClasspathResolver.resolveResource(...)` to forward the resolved `base` URI down into the new `ClasspathInput` constructor, which the issue explicitly called out.

### Test plan

* Two commits: the first adds a failing test, the second implements the fix.
* The seven tests in `ClasspathInputTest` (including the pre-existing one) pass against the fix.
* Locally, `mvn -B '-Dtest=!StrictXMLTest' test` runs 442 tests, 0 failures, 0 errors (the two skipped are pre-existing `@Disabled` cases in `XMLDocumentTest`). `StrictXMLTest` is skipped here because its `@BeforeEach` requires reaching `w3.org`, which is not available from my sandbox.

### CI note

The `mvn -Pqulice` job on this PR fails the same way it fails on `master` since commit `af882bc` ("fixes", which bumped `qulice-maven-plugin` from `0.24.0` to `0.25.1`) — every recent renovate PR is failing the same step.

I checked locally: `mvn -B -Pqulice verify` reports **96** violations on `master` and **96** on this branch (same set, just shifted line numbers in `ClasspathInput.java` and `ClasspathInputTest.java`). This PR adds zero new qulice violations. The 96 baseline violations live in unrelated test files (`XMLDocumentTest`, `XPathContextTest`, `XSLChainTest`, `XSLDocumentTest`) and look out of scope for #119, but happy to send a follow-up if you want.