### PR TITLE
Add Architecture section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,58 @@ String name = item.xpath("text()").get(0);
 System.out.println(xml.toString());
 ```
 
+## Architecture
+
+The library defines three core interfaces: `XML`, `XSL`, and `Sources`.
+All concrete classes implement one of these interfaces, and callers
+  program against the interfaces exclusively.
+This differs from typical Java XML code that couples callers directly
+  to [JAXP][jaxp] types such as `Document`, `Transformer`, or `SAXParser`.
+New contributors add implementations of these interfaces, not subclasses
+  of existing concrete types.
+
+All implementations are immutable and thread-safe.
+Operations that would alter state — `registerNs()` on `XML` and `with()`
+  on `XSL` — return new objects rather than modifying existing ones.
+The [W3C DOM][dom] `Document` is mutable by design and requires external
+  synchronization under concurrent access; this library avoids that
+  structurally.
+
+Two implementations of `XML` exist for different [XPath][xpath] needs.
+[`XMLDocument`][xmldoc] wraps the JDK's [JAXP][jaxp] processor,
+  which supports [XPath 1.0][xpath1] and is thread-safe.
+[`SaxonDocument`][saxondoc] uses [Saxon-HE][saxon] and supports
+  [XPath 2.0][xpath2] and above, but is not thread-safe.
+Callers who need typed comparisons, sequences, or advanced `fn:` functions
+  must use `SaxonDocument`; others should prefer `XMLDocument`.
+
+[XSD][xsd] validation is enforced through the [`StrictXML`][strictxml]
+  decorator, which wraps any `XML` and throws during construction
+  if the document is invalid.
+Libraries such as [dom4j][dom4j] or plain JAXP leave validation as an
+  explicit separate call; here it becomes a structural guarantee at
+  object-creation time.
+
+[XSLT][xslt] stylesheets are composed with [`XSLChain`][xslchain],
+  which accepts an ordered list of `XSL` instances and applies each
+  in sequence, feeding the output of one as the input to the next.
+Without this class, callers must manage intermediate `XML` objects
+  between transformation steps manually.
+
+[`XSLDocument`][xsldoc] uses [Saxon][saxon] as its [XSLT][xslt] engine
+  instead of the JDK's built-in transformer.
+Saxon supports [XSLT 2.0][xslt2] and [XSLT 3.0][xslt3]; the JDK bundled
+  transformer supports only [XSLT 1.0][xslt1].
+Saxon is therefore a required runtime dependency despite the library's
+  narrow scope.
+
+XSD schemas and XSLT imports (`xsl:include`, `xsl:import`) are resolved
+  from the JVM classpath via [`ClasspathResolver`][cpresolver] and
+  [`ClasspathSources`][cpsources].
+This is necessary when schemas and stylesheets are packaged inside JAR
+  archives, where absolute filesystem paths are unavailable at runtime.
+For external files, [`FileSources`][filesources] is the alternative.
+
 ## How to contribute?
 
 Fork the repository, make changes, submit a pull request.
@@ -37,3 +89,23 @@ mvn clean install -Pqulice
 ```
 
 [blog]: http://www.yegor256.com/2014/04/24/java-xml-parsing-and-traversing.html
+[jaxp]: https://docs.oracle.com/javase/tutorial/jaxp/
+[dom]: https://www.w3.org/DOM/
+[xpath]: https://www.w3.org/TR/xpath-datamodel/
+[xpath1]: https://www.w3.org/TR/xpath-10/
+[xpath2]: https://www.w3.org/TR/xpath20/
+[saxon]: https://www.saxonica.com/welcome/welcome.xml
+[xsd]: https://www.w3.org/XML/Schema
+[xslt]: https://www.w3.org/TR/xslt-30/
+[xslt1]: https://www.w3.org/TR/xslt-10/
+[xslt2]: https://www.w3.org/TR/xslt20/
+[xslt3]: https://www.w3.org/TR/xslt-30/
+[dom4j]: https://dom4j.github.io/
+[xmldoc]: src/main/java/com/jcabi/xml/XMLDocument.java
+[saxondoc]: src/main/java/com/jcabi/xml/SaxonDocument.java
+[xsldoc]: src/main/java/com/jcabi/xml/XSLDocument.java
+[xslchain]: src/main/java/com/jcabi/xml/XSLChain.java
+[strictxml]: src/main/java/com/jcabi/xml/StrictXML.java
+[cpresolver]: src/main/java/com/jcabi/xml/ClasspathResolver.java
+[cpsources]: src/main/java/com/jcabi/xml/ClasspathSources.java
+[filesources]: src/main/java/com/jcabi/xml/FileSources.java


### PR DESCRIPTION
@yegor256, this PR adds an Architecture section to the README.

The section is placed right before the How to Contribute section, as the second heading in the document. It covers six key design decisions:

1. **Interface-based API** — `XML`, `XSL`, and `Sources` are the three core interfaces; callers never depend on JAXP types directly.
2. **Immutability** — all implementations are immutable and thread-safe; state-changing operations return new objects, unlike W3C DOM.
3. **Dual XPath engine** — `XMLDocument` (JDK/XPath 1.0, thread-safe) vs `SaxonDocument` (Saxon-HE/XPath 2.0, not thread-safe); explains when to use each.
4. **StrictXML decorator** — validation against XSD is enforced at construction time rather than as a separate optional call.
5. **XSLChain pipeline** — composes multiple XSLT stylesheets into a sequence without manual intermediate object management.
6. **Classpath resource resolution** — `ClasspathResolver` and `ClasspathSources` resolve XSD/XSLT imports from JAR-packaged resources.

Each decision includes Markdown links to relevant standards and technologies (JAXP, W3C DOM, XPath, XSD, XSLT, Saxon, dom4j) and links to the concrete source files in the repository.

Markdown formatting follows the 80-character line rule with two-space continuation indentation. `markdownlint` reports no warnings.