### PR TITLE
#120: Increase timeout in parsesInMultipleThreads to 30s

### DIFF
--- a/src/test/java/com/jcabi/xml/XMLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XMLDocumentTest.java
@@ -340,7 +340,7 @@ final class XMLDocumentTest {
     @SuppressWarnings("PMD.CloseResource")
     @Test
     void parsesInMultipleThreads() throws Exception {
-        final int timeout = 10;
+        final int timeout = 30;
         final int loop = 100;
         final Runnable runnable = () -> MatcherAssert.assertThat(
             new XMLDocument("<root><hey/></root>"),

--- a/src/test/java/com/jcabi/xml/XMLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XMLDocumentTest.java
@@ -358,6 +358,20 @@ final class XMLDocumentTest {
         service.shutdownNow();
     }
 
+    @RepeatedTest(5)
+    void parsesConsistentlyInMultipleThreads() {
+        final int total = 50;
+        MatcherAssert.assertThat(
+            "All concurrent XML parsings must complete and produce matching XPath results",
+            new Together<>(
+                total,
+                thread -> new XMLDocument("<root><hey/></root>")
+                    .nodes("/root/hey").size()
+            ).asList(),
+            Matchers.everyItem(Matchers.equalTo(1))
+        );
+    }
+
     @SuppressWarnings("PMD.CloseResource")
     @Test
     void xpathInMultipleThreads() throws Exception {


### PR DESCRIPTION
@yegor256 this PR resolves issue #120, where the parsesInMultipleThreads test in XMLDocumentTest was occasionally failing on slower machines because its awaitTermination timeout was set to 10 seconds, while every other multi-threaded test in the same class uses 30 seconds.

What changed:
- src/test/java/com/jcabi/xml/XMLDocumentTest.java: increased the timeout in parsesInMultipleThreads from 10 to 30 seconds, matching the convention already used by xpathInMultipleThreads.
- src/test/java/com/jcabi/xml/XMLDocumentTest.java: added a new parsesConsistentlyInMultipleThreads regression test that uses the project standard Together concurrency helper (the same helper used in XSLDocumentTest.transformsInManyThreads and StrictXMLTest), and is marked @RepeatedTest(5) so flakiness would surface quickly. Unlike the older pattern based on ExecutorService.submit, this assertion fails loudly when concurrent parses produce wrong results, instead of silently swallowing exceptions thrown inside the runnable.

Verification:
- mvn --batch-mode --errors clean install -Pqulice passes locally.
- All 14 CI checks are green: mvn matrix (ubuntu-24.04, macos-15, windows-2022) x (Java 21, Java 22), plus actionlint, markdown-lint, yamllint, xcop, pdd, typos, copyrights, reuse.

Ready for merge.