### PR TITLE
#105 Add test for empty XSL stylesheet

### DIFF
--- a/src/test/java/com/jcabi/xml/XSLDocumentTest.java
+++ b/src/test/java/com/jcabi/xml/XSLDocumentTest.java
@@ -247,6 +247,23 @@ final class XSLDocumentTest {
         );
     }
 
+    @Test
+    void emptyStylesheetExtractsTextContent() {
+        final XSL xsl = new XSLDocument(
+            StringUtils.join(
+                "<xsl:stylesheet  ",
+                " xmlns:xsl='http://www.w3.org/1999/XSL/Transform' ",
+                " version='2.0' >",
+                "</xsl:stylesheet>"
+            )
+        );
+        MatcherAssert.assertThat(
+            "Empty stylesheet should apply XSLT default templates and return text content",
+            xsl.applyTo(new XMLDocument("<a><b>hello</b><c>world</c></a>")),
+            Matchers.containsString("helloworld")
+        );
+    }
+
     @RepeatedTest(10)
     void transformsInManyThreads() throws Exception {
         final XSL xsl = new XSLDocument(


### PR DESCRIPTION
@yegor256 this PR closes #105 by adding the missing regression test for the empty `<xsl:stylesheet>` case from the issue.

## What was missing

`XSLDocumentTest` had no coverage for the empty-stylesheet input shown in the issue body:

```xml
<xsl:stylesheet xmlns:xsl='http://www.w3.org/1999/XSL/Transform' version='2.0'></xsl:stylesheet>
```

## What this adds

A new test `emptyStylesheetExtractsTextContent` that:

1. Constructs an `XSLDocument` from the empty stylesheet from the issue.
2. Calls `applyTo(...)` on `<a><b>hello</b><c>world</c></a>`.
3. Asserts the output contains `helloworld`, which is the documented XSLT behavior: with no template rules defined, the built-in templates traverse the tree and emit text nodes verbatim, so the concatenated text content is the expected result.

This pins the documented XSLT default-rules behavior so future regressions in `XSLDocument` (e.g. accidentally rejecting an empty stylesheet at construction time, or breaking text extraction) will be caught.

## Verification

- `mvn -B clean install -Pqulice` passes locally on Java 21.
- All 14 CI checks are green on this PR.
