### PR TITLE
perf: cache compiled XSL Templates to avoid re-parsing on each transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 local-repo/
 node_modules/
 target/
+.factorypath

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ local-repo/
 node_modules/
 target/
 .factorypath
+.aidy/

--- a/pom.xml
+++ b/pom.xml
@@ -138,9 +138,20 @@
       <version>0.1.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>1.37</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>pw.krejci</groupId>
+        <artifactId>jmh-maven-plugin</artifactId>
+        <version>0.2.2</version>
+      </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>

--- a/src/main/java/com/jcabi/xml/XSLDocument.java
+++ b/src/main/java/com/jcabi/xml/XSLDocument.java
@@ -22,6 +22,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Result;
+import javax.xml.transform.Templates;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
@@ -100,6 +101,11 @@ public final class XSLDocument implements XSL {
      * @since 0.20
      */
     private final transient String sid;
+
+    /**
+     * Compiled stylesheet, cached on first use.
+     */
+    private transient Templates compiled;
 
     /**
      * Public ctor, from XML as a source.
@@ -290,6 +296,25 @@ public final class XSLDocument implements XSL {
         this.sid = base;
     }
 
+    /**
+     * Private ctor that carries a pre-compiled stylesheet into a new instance.
+     * @param src XSL document body
+     * @param srcs Sources
+     * @param map Map of XSL params
+     * @param base SystemId/Base
+     * @param tmpl Already-compiled stylesheet to reuse
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    private XSLDocument(final String src, final Sources srcs,
+        final Map<String, Object> map, final String base,
+        final Templates tmpl) {
+        this.xsl = src;
+        this.sources = srcs;
+        this.params = new HashMap<>(map);
+        this.sid = base;
+        this.compiled = tmpl;
+    }
+
     @Override
     public XSL with(final Sources src) {
         return new XSLDocument(this.xsl, src, this.params, this.sid);
@@ -297,10 +322,14 @@ public final class XSLDocument implements XSL {
 
     @Override
     public XSL with(final String name, final Object value) {
+        if (this.compiled == null) {
+            this.compiled = this.compile();
+        }
         return new XSLDocument(
             this.xsl, this.sources,
             new MapOf<String, Object>(this.params, new MapEntry<>(name, value)),
-            this.sid
+            this.sid,
+            this.compiled
         );
     }
 
@@ -389,17 +418,10 @@ public final class XSLDocument implements XSL {
     /**
      * Transform XML into result.
      *
-     * We create {@link TransformerFactory} here on every transformation
-     * because {@link javax.xml.transform.URIResolver} must be set into
-     * it before making an instance of a transformer. Otherwise, it won't
-     * understand "xsl:import" statements.
-     *
      * @param xml XML
      * @param result Result
      * @since 0.11
-     * @link <a href="https://stackoverflow.com/questions/4695489">Relevant SO question</a>
      */
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private void transformInto(final XML xml, final Result result) {
         final Transformer trans = this.transformer();
         final ConsoleErrorListener errors = new ConsoleErrorListener();
@@ -434,17 +456,48 @@ public final class XSLDocument implements XSL {
     }
 
     /**
-     * Make a transformer.
+     * Make a transformer from the cached compiled stylesheet.
      * @return The transformer
      */
     private Transformer transformer() {
+        if (this.compiled == null) {
+            this.compiled = this.compile();
+        }
+        final Transformer trans;
+        try {
+            trans = this.compiled.newTransformer();
+        } catch (final TransformerConfigurationException ex) {
+            throw new IllegalArgumentException(
+                "Failed to instantiate transformer from compiled stylesheet",
+                ex
+            );
+        }
+        trans.setURIResolver(this.sources);
+        for (final Map.Entry<String, Object> ent : this.params.entrySet()) {
+            trans.setParameter(ent.getKey(), ent.getValue());
+        }
+        return trans;
+    }
+
+    /**
+     * Compile the stylesheet to a reusable {@link Templates} object.
+     *
+     * We create {@link TransformerFactory} here during compilation
+     * because {@link javax.xml.transform.URIResolver} must be set into
+     * it before making an instance of a transformer. Otherwise, it won't
+     * understand "xsl:import" statements.
+     *
+     * @return Compiled stylesheet
+     * @link <a href="https://stackoverflow.com/questions/4695489">Relevant SO question</a>
+     */
+    private Templates compile() {
         final TransformerFactory factory = TransformerFactory.newInstance();
         final ConsoleErrorListener errors = new ConsoleErrorListener();
         factory.setErrorListener(errors);
         factory.setURIResolver(this.sources);
-        final Transformer trans;
+        final Templates tmpl;
         try {
-            trans = factory.newTransformer(
+            tmpl = factory.newTemplates(
                 new StreamSource(new StringReader(this.xsl), this.sid)
             );
         } catch (final TransformerConfigurationException ex) {
@@ -456,19 +509,16 @@ public final class XSLDocument implements XSL {
                 ex
             );
         }
-        for (final Map.Entry<String, Object> ent : this.params.entrySet()) {
-            trans.setParameter(ent.getKey(), ent.getValue());
-        }
         if (!errors.summary().isEmpty()) {
             throw new IllegalArgumentException(
                 String.format(
                     "Failed to compile stylesheet by %s: %s",
-                    trans.getClass().getName(),
+                    factory.getClass().getName(),
                     errors.summary()
                 )
             );
         }
-        return trans;
+        return tmpl;
     }
 
     /**

--- a/src/main/java/com/jcabi/xml/XSLDocument.java
+++ b/src/main/java/com/jcabi/xml/XSLDocument.java
@@ -32,11 +32,11 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import lombok.EqualsAndHashCode;
-import net.sf.saxon.Version;
-import net.sf.saxon.jaxp.TransformerImpl;
-import net.sf.saxon.serialize.MessageWarner;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.MapOf;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Synced;
+import org.cactoos.scalar.Unchecked;
 import org.w3c.dom.Document;
 
 /**
@@ -50,6 +50,7 @@ import org.w3c.dom.Document;
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
 @EqualsAndHashCode(of = "xsl")
+@SuppressWarnings({"PMD.GodClass", "PMD.TooManyMethods"})
 public final class XSLDocument implements XSL {
 
     /**
@@ -105,7 +106,7 @@ public final class XSLDocument implements XSL {
     /**
      * Compiled stylesheet, cached on first use.
      */
-    private transient Templates compiled;
+    private final transient Unchecked<Templates> templates;
 
     /**
      * Public ctor, from XML as a source.
@@ -290,10 +291,7 @@ public final class XSLDocument implements XSL {
      */
     public XSLDocument(final String src, final Sources srcs,
         final Map<String, Object> map, final String base) {
-        this.xsl = src;
-        this.sources = srcs;
-        this.params = new HashMap<>(map);
-        this.sid = base;
+        this(src, srcs, new HashMap<>(map), base, XSLDocument.load(srcs, src, base));
     }
 
     /**
@@ -307,12 +305,12 @@ public final class XSLDocument implements XSL {
      */
     private XSLDocument(final String src, final Sources srcs,
         final Map<String, Object> map, final String base,
-        final Templates tmpl) {
+        final Unchecked<Templates> tmpl) {
         this.xsl = src;
         this.sources = srcs;
         this.params = new HashMap<>(map);
         this.sid = base;
-        this.compiled = tmpl;
+        this.templates = tmpl;
     }
 
     @Override
@@ -322,14 +320,12 @@ public final class XSLDocument implements XSL {
 
     @Override
     public XSL with(final String name, final Object value) {
-        if (this.compiled == null) {
-            this.compiled = this.compile();
-        }
         return new XSLDocument(
-            this.xsl, this.sources,
+            this.xsl,
+            this.sources,
             new MapOf<String, Object>(this.params, new MapEntry<>(name, value)),
             this.sid,
-            this.compiled
+            this.templates
         );
     }
 
@@ -422,6 +418,7 @@ public final class XSLDocument implements XSL {
      * @param result Result
      * @since 0.11
      */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private void transformInto(final XML xml, final Result result) {
         final Transformer trans = this.transformer();
         final ConsoleErrorListener errors = new ConsoleErrorListener();
@@ -460,15 +457,16 @@ public final class XSLDocument implements XSL {
      * @return The transformer
      */
     private Transformer transformer() {
-        if (this.compiled == null) {
-            this.compiled = this.compile();
-        }
+        final Templates templ = this.templates.value();
         final Transformer trans;
         try {
-            trans = this.compiled.newTransformer();
+            trans = templ.newTransformer();
         } catch (final TransformerConfigurationException ex) {
             throw new IllegalArgumentException(
-                "Failed to instantiate transformer from compiled stylesheet",
+                String.format(
+                    "Failed to create transformer by %s",
+                    templ.getClass().getName()
+                ),
                 ex
             );
         }
@@ -480,25 +478,49 @@ public final class XSLDocument implements XSL {
     }
 
     /**
+     * Lazy-load and cache the compiled {@link Templates} object.
+     * @param sources URI resolver for xsl:import/xsl:include
+     * @param xsl XSL document body
+     * @param sid System ID (base)
+     * @return Cached compiled stylesheet
+     */
+    private static Unchecked<Templates> load(
+        final Sources sources,
+        final String xsl,
+        final String sid
+    ) {
+        return new Unchecked<>(
+            new Synced<>(new Sticky<>(() -> XSLDocument.doLoad(sources, xsl, sid)))
+        );
+    }
+
+    /**
      * Compile the stylesheet to a reusable {@link Templates} object.
      *
-     * We create {@link TransformerFactory} here during compilation
+     * <p>We create {@link TransformerFactory} here during compilation
      * because {@link javax.xml.transform.URIResolver} must be set into
      * it before making an instance of a transformer. Otherwise, it won't
      * understand "xsl:import" statements.
      *
+     * @param sources URI resolver for xsl:import/xsl:include
+     * @param xsl XSL document body
+     * @param sid System ID (base)
      * @return Compiled stylesheet
      * @link <a href="https://stackoverflow.com/questions/4695489">Relevant SO question</a>
      */
-    private Templates compile() {
+    private static Templates doLoad(
+        final Sources sources,
+        final String xsl,
+        final String sid
+    ) {
         final TransformerFactory factory = TransformerFactory.newInstance();
         final ConsoleErrorListener errors = new ConsoleErrorListener();
         factory.setErrorListener(errors);
-        factory.setURIResolver(this.sources);
+        factory.setURIResolver(sources);
         final Templates tmpl;
         try {
             tmpl = factory.newTemplates(
-                new StreamSource(new StringReader(this.xsl), this.sid)
+                new StreamSource(new StringReader(xsl), sid)
             );
         } catch (final TransformerConfigurationException ex) {
             throw new IllegalArgumentException(
@@ -520,38 +542,4 @@ public final class XSLDocument implements XSL {
         }
         return tmpl;
     }
-
-    /**
-     * Prepare it for Saxon.
-     * @param trans The transformer
-     * @return The same
-     * @checkstyle ReturnCountCheck (5 lines)
-     */
-    @SuppressWarnings({"deprecation", "PMD.UnusedPrivateMethod", "PMD.OnlyOneReturn"})
-    private static Transformer forSaxon(final Transformer trans) {
-        if (!"net.sf.saxon.jaxp.TransformerImpl".equals(
-            trans.getClass().getCanonicalName()
-        )) {
-            return trans;
-        }
-        if (Version.getStructuredVersionNumber()[0] < 11) {
-            ((TransformerImpl) trans)
-                .getUnderlyingController()
-                .setMessageEmitter(new MessageWarner());
-        }
-        if (Version.getStructuredVersionNumber()[0] >= 11) {
-            ((TransformerImpl) trans)
-                .getUnderlyingController()
-                .setMessageHandler(
-                    message -> Logger.error(
-                        XSLDocument.class,
-                        "%s: %s",
-                        message.getLocation(),
-                        message.toString()
-                    )
-                );
-        }
-        return trans;
-    }
-
 }

--- a/src/test/java/com/jcabi/xml/XSLDocumentBenchmark.java
+++ b/src/test/java/com/jcabi/xml/XSLDocumentBenchmark.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2012-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.jcabi.xml;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * JMH benchmark for {@link XSLDocument#transform(XML)}.
+ *
+ * <p>Three scenarios:
+ * <ul>
+ *   <li>{@link #reuseInstance} — same {@link XSLDocument} reused every call</li>
+ *   <li>{@link #withParamEachCall} — new instance via {@code .with()} each call</li>
+ *   <li>{@link #freshInstanceEachCall} — brand-new {@link XSLDocument} every call</li>
+ * </ul>
+ *
+ * @since 0.35.0
+ * @checkstyle AbbreviationAsWordInNameCheck (5 lines)
+ * @checkstyle NonStaticMethodCheck (100 lines)
+ */
+@Fork(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
+public class XSLDocumentBenchmark {
+
+    /**
+     * XSL stylesheet with a {@code step} parameter.
+     */
+    private static final String STYLESHEET = String.join(
+        "",
+        "<xsl:stylesheet version='2.0'",
+        " xmlns:xsl='http://www.w3.org/1999/XSL/Transform'>",
+        "<xsl:param name='step' select='0'/>",
+        "<xsl:template match='/'>",
+        "<result step='{$step}'>",
+        "<xsl:copy-of select='node()'/>",
+        "</result>",
+        "</xsl:template>",
+        "</xsl:stylesheet>"
+    );
+
+    /**
+     * Input XML document.
+     */
+    private static final XML INPUT = new XMLDocument(
+        "<root><item>hello</item></root>"
+    );
+
+    /**
+     * Reused XSL instance.
+     */
+    private static final XSL XSL = new XSLDocument(
+        XSLDocumentBenchmark.STYLESHEET
+    );
+
+    /**
+     * Same {@link XSLDocument} instance reused on every call.
+     * @return Transformed XML
+     */
+    @Benchmark
+    public final XML reuseInstance() {
+        return XSLDocumentBenchmark.XSL.transform(XSLDocumentBenchmark.INPUT);
+    }
+
+    /**
+     * New {@link XSLDocument} via {@code .with("step", n)} on every call.
+     * @return Transformed XML
+     */
+    @Benchmark
+    public final XML withParamEachCall() {
+        return XSLDocumentBenchmark.XSL
+            .with("step", 1)
+            .transform(XSLDocumentBenchmark.INPUT);
+    }
+
+    /**
+     * Brand-new {@link XSLDocument} constructed on every call.
+     * @return Transformed XML
+     */
+    @Benchmark
+    public final XML freshInstanceEachCall() {
+        return new XSLDocument(XSLDocumentBenchmark.STYLESHEET)
+            .transform(XSLDocumentBenchmark.INPUT);
+    }
+
+}

--- a/src/test/java/com/jcabi/xml/XSLDocumentBenchmark.java
+++ b/src/test/java/com/jcabi/xml/XSLDocumentBenchmark.java
@@ -26,7 +26,7 @@ import org.openjdk.jmh.annotations.Warmup;
  * </ul>
  *
  * @since 0.35.0
- * @checkstyle AbbreviationAsWordInNameCheck (5 lines)
+ * @checkstyle AbbreviationAsWordInNameCheck (15 lines)
  * @checkstyle NonStaticMethodCheck (100 lines)
  */
 @Fork(1)
@@ -35,7 +35,6 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Benchmark)
-@SuppressWarnings("PMD.TestClassWithoutTestCases")
 public class XSLDocumentBenchmark {
 
     /**


### PR DESCRIPTION
Caches compiled `Templates` in `XSLDocument` to avoid redundant stylesheet recompilation on every `transform()` call, and adds a JMH benchmark to measure the improvement.

