### PR TITLE
document UTF-8 decoding for XMLDocument stream, URL, and URI ctors

### DIFF
--- a/src/main/java/com/jcabi/xml/XMLDocument.java
+++ b/src/main/java/com/jcabi/xml/XMLDocument.java
@@ -188,6 +188,11 @@ public final class XMLDocument implements XML {
      * <p>An {@link IllegalArgumentException} is thrown if the parameter
      * passed is not in XML format.
      *
+     * <p>The bytes read from the stream are decoded as UTF-8 regardless of
+     * any XML prolog encoding declaration; callers that need a different
+     * charset must decode the stream themselves and use
+     * {@link XMLDocument#XMLDocument(String)}.
+     *
      * <p>The provided input stream will be closed automatically after
      * getting data from it.
      *
@@ -210,6 +215,9 @@ public final class XMLDocument implements XML {
      * <p>An {@link IllegalArgumentException} is thrown if the parameter
      * passed is not in XML format.
      *
+     * <p>The resource at the URL is decoded as UTF-8 regardless of any XML
+     * prolog encoding declaration or HTTP {@code Content-Type} charset.
+     *
      * @param url The URL to load from
      * @throws IOException In case of I/O problems
      */
@@ -226,6 +234,9 @@ public final class XMLDocument implements XML {
      *
      * <p>An {@link IllegalArgumentException} is thrown if the parameter
      * passed is not in XML format.
+     *
+     * <p>The resource at the URI is decoded as UTF-8 regardless of any XML
+     * prolog encoding declaration.
      *
      * @param uri The URI to load from
      * @throws IOException In case of I/O problems


### PR DESCRIPTION
Issue #103 asked for the byte-to-text encoding of the `XSDDocumentTest` validators to be supplied explicitly. The test class was later folded into `XMLDocumentTest`, where the validators run on `String` literals, so the original report's exact target no longer exists. The deeper concern — callers cannot tell which charset the non-`String` constructors of `XMLDocument` use — still holds: `XMLDocument(InputStream)`, `XMLDocument(URL)`, and `XMLDocument(URI)` all route through `TextResource`, which decodes bytes as UTF-8, but neither the Javadoc on those constructors nor the issue's open thread says so.

The change adds three short `<p>` blocks to the Javadoc of those three constructors stating that the bytes are decoded as UTF-8 regardless of any XML prolog or HTTP `Content-Type` charset, and pointing callers who need a different charset at `XMLDocument(String)`. No production code paths change.

Verified with `mvn --batch-mode -DskipITs -Dinvoker.skip=true -Pqulice test` (646 tests, 0 failures, Qulice clean) and `mvn --batch-mode -DskipTests -DskipITs -Dinvoker.skip=true javadoc:javadoc` (no new warnings).

Closes #103
